### PR TITLE
修正文档中代码示例中的笔误

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -204,11 +204,11 @@ defer session.Close()
 var user Userinfo
 session.Where("id=?", 27).Get(&user)
 
-var user2 Userinfo
-session.Where("name = ?", "john").Get(&user3) // more complex query
+var userJohn Userinfo
+session.Where("name = ?", "john").Get(&userJohn) // more complex query
 
-var user3 Userinfo
-session.Where("name = ? and age < ?", "john", 88).Get(&user4) // even more complex
+var userOldJohn Userinfo
+session.Where("name = ? and age > ?", "john", 88).Get(&userOldJohn) // even more complex
 ```
 
 2.获取多个对象


### PR DESCRIPTION
1. 修正变量名错误
2. 修改查询示例的查询，让代码更易懂
