### PR TITLE
analysis mysql conn string for get charset. set charset when use Sync()

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -67,6 +67,7 @@ type Engine struct {
 	Logger         io.Writer
 	Cacher         Cacher
 	UseCache       bool
+	charset        string
 }
 
 func (engine *Engine) SetMapper(mapper IMapper) {

--- a/xorm.go
+++ b/xorm.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strings"
 	"sync"
 )
 
@@ -28,6 +29,11 @@ func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
 		engine.dialect = &sqlite3{}
 	} else if driverName == MYSQL {
 		engine.dialect = &mysql{}
+		index := strings.Index(strings.ToLower(dataSourceName), "charset=")
+		tempstr := dataSourceName[index+8:]
+		index = strings.Index(strings.ToLower(tempstr), "&")
+		tempstr = tempstr[:index]
+		engine.charset = tempstr
 	} else if driverName == POSTGRES {
 		engine.dialect = &postgres{}
 		engine.Filters = append(engine.Filters, &PgSeqFilter{})


### PR DESCRIPTION
hi,i'm using xorm.and i found when i sync table(create it).
the table is not support chinese word yet .
Even though open db like this : root:<password>@tcp(<ip>:3306)/crawler?charset=utf8
and i found CharSet() method in session.go and statement.go
but i can't find it in engine
so,i don't konw how to use it.
and i commit this to support chinese word
