### PR TITLE
fixbug: xorm reverse; miss empty string for default value

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -623,9 +623,24 @@ func (engine *Engine) mapType(t reflect.Type) *Table {
 			}
 		} else {
 			sqlType := Type2SQLType(fieldType)
-			col = &Column{engine.columnMapper.Obj2Table(t.Field(i).Name), t.Field(i).Name, sqlType,
-				sqlType.DefaultLength, sqlType.DefaultLength2, true, "", make(map[string]bool), false, false,
-				TWOSIDES, false, false, false, false}
+			col = &Column{
+				Name:			engine.columnMapper.Obj2Table(t.Field(i).Name),
+				FieldName:		t.Field(i).Name,
+				SQLType:		sqlType,
+				Length:			sqlType.DefaultLength,
+				Length2:		sqlType.DefaultLength2,
+				Nullable:		true,
+				Default:		"",
+				Indexes:		make(map[string]bool),
+				IsPrimaryKey:	false,
+				IsAutoIncrement:false,
+				MapType:		TWOSIDES,
+				IsCreated:		false,
+				IsUpdated:		false,
+				IsCascade:		false,
+				IsVersion:		false,
+				DefaultIsEmpty:	false,
+			}
 		}
 		if col.IsAutoIncrement {
 			col.Nullable = false

--- a/mssql.go
+++ b/mssql.go
@@ -136,8 +136,8 @@ func (db *mssql) TableCheckSql(tableName string) (string, []interface{}) {
 
 func (db *mssql) GetColumns(tableName string) ([]string, map[string]*Column, error) {
 	args := []interface{}{}
-	s := `select a.name as name, b.name as ctype,a.max_length,a.precision,a.scale 
-from sys.columns a left join sys.types b on a.user_type_id=b.user_type_id 
+	s := `select a.name as name, b.name as ctype,a.max_length,a.precision,a.scale
+from sys.columns a left join sys.types b on a.user_type_id=b.user_type_id
 where a.object_id=object_id('` + tableName + `')`
 	cnn, err := sql.Open(db.driverName, db.dataSourceName)
 	if err != nil {
@@ -187,6 +187,10 @@ where a.object_id=object_id('` + tableName + `')`
 		if col.SQLType.IsText() {
 			if col.Default != "" {
 				col.Default = "'" + col.Default + "'"
+			}else{
+				if col.DefaultIsEmpty {
+					col.Default = "''"
+				}
 			}
 		}
 		cols[col.Name] = col
@@ -224,18 +228,18 @@ func (db *mssql) GetTables() ([]*Table, error) {
 
 func (db *mssql) GetIndexes(tableName string) (map[string]*Index, error) {
 	args := []interface{}{tableName}
-	s := `SELECT  
-IXS.NAME                    AS  [INDEX_NAME],  
-C.NAME                      AS  [COLUMN_NAME], 
-IXS.is_unique AS [IS_UNIQUE], 
-CASE    IXCS.IS_INCLUDED_COLUMN   
-WHEN    0   THEN    'NONE' 
-ELSE    'INCLUDED'  END     AS  [IS_INCLUDED_COLUMN]  
-FROM SYS.INDEXES IXS  
-INNER JOIN SYS.INDEX_COLUMNS   IXCS  
-ON IXS.OBJECT_ID=IXCS.OBJECT_ID  AND IXS.INDEX_ID = IXCS.INDEX_ID  
-INNER   JOIN SYS.COLUMNS C  ON IXS.OBJECT_ID=C.OBJECT_ID  
-AND IXCS.COLUMN_ID=C.COLUMN_ID  
+	s := `SELECT
+IXS.NAME                    AS  [INDEX_NAME],
+C.NAME                      AS  [COLUMN_NAME],
+IXS.is_unique AS [IS_UNIQUE],
+CASE    IXCS.IS_INCLUDED_COLUMN
+WHEN    0   THEN    'NONE'
+ELSE    'INCLUDED'  END     AS  [IS_INCLUDED_COLUMN]
+FROM SYS.INDEXES IXS
+INNER JOIN SYS.INDEX_COLUMNS   IXCS
+ON IXS.OBJECT_ID=IXCS.OBJECT_ID  AND IXS.INDEX_ID = IXCS.INDEX_ID
+INNER   JOIN SYS.COLUMNS C  ON IXS.OBJECT_ID=C.OBJECT_ID
+AND IXCS.COLUMN_ID=C.COLUMN_ID
 WHERE IXS.TYPE_DESC='NONCLUSTERED' and OBJECT_NAME(IXS.OBJECT_ID) =?
 `
 	cnn, err := sql.Open(db.driverName, db.dataSourceName)

--- a/mysql.go
+++ b/mysql.go
@@ -212,6 +212,9 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*Column, err
 			case "COLUMN_DEFAULT":
 				// add ''
 				col.Default = string(content)
+				if col.Default == "" {
+					col.DefaultIsEmpty = true
+				}
 			case "COLUMN_TYPE":
 				cts := strings.Split(string(content), "(")
 				var len1, len2 int
@@ -256,6 +259,10 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*Column, err
 		if col.SQLType.IsText() {
 			if col.Default != "" {
 				col.Default = "'" + col.Default + "'"
+			}else{
+				if col.DefaultIsEmpty {
+					col.Default = "''"
+				}
 			}
 		}
 		cols[col.Name] = col

--- a/oracle.go
+++ b/oracle.go
@@ -139,6 +139,9 @@ func (db *oracle) GetColumns(tableName string) ([]string, map[string]*Column, er
 				col.Name = strings.Trim(string(content), `" `)
 			case "data_default":
 				col.Default = string(content)
+				if col.Default == "" {
+					col.DefaultIsEmpty = true
+				}
 			case "nullable":
 				if string(content) == "Y" {
 					col.Nullable = true
@@ -171,6 +174,10 @@ func (db *oracle) GetColumns(tableName string) ([]string, map[string]*Column, er
 		if col.SQLType.IsText() {
 			if col.Default != "" {
 				col.Default = "'" + col.Default + "'"
+			}else{
+				if col.DefaultIsEmpty {
+					col.Default = "''"
+				}
 			}
 		}
 		cols[col.Name] = col

--- a/postgres.go
+++ b/postgres.go
@@ -177,6 +177,9 @@ func (db *postgres) GetColumns(tableName string) ([]string, map[string]*Column, 
 					col.IsPrimaryKey = true
 				} else {
 					col.Default = string(content)
+					if col.Default == "" {
+						col.DefaultIsEmpty = true
+					}
 				}
 			case "is_nullable":
 				if string(content) == "YES" {
@@ -218,6 +221,10 @@ func (db *postgres) GetColumns(tableName string) ([]string, map[string]*Column, 
 		if col.SQLType.IsText() {
 			if col.Default != "" {
 				col.Default = "'" + col.Default + "'"
+			}else{
+				if col.DefaultIsEmpty {
+					col.Default = "''"
+				}
 			}
 		}
 		cols[col.Name] = col

--- a/table.go
+++ b/table.go
@@ -275,6 +275,7 @@ type Column struct {
 	IsUpdated       bool
 	IsCascade       bool
 	IsVersion       bool
+	DefaultIsEmpty  bool
 }
 
 // generate column description string according dialect

--- a/xorm/go.go
+++ b/xorm/go.go
@@ -241,7 +241,7 @@ func tag(table *xorm.Table, col *xorm.Column) string {
     nstr := col.SQLType.Name
     if col.Length != 0 {
         if col.Length2 != 0 {
-            nstr += fmt.Sprintf("(%v, %v)", col.Length, col.Length2)
+            nstr += fmt.Sprintf("(%v,%v)", col.Length, col.Length2)
         } else {
             nstr += fmt.Sprintf("(%v)", col.Length)
         }

--- a/xorm/templates/goxorm/config
+++ b/xorm/templates/goxorm/config
@@ -1,2 +1,3 @@
 lang=go
 genJson=0
+prefix=cos_


### PR DESCRIPTION
一、xorm反转工具bug修复：
1、xorm反转工具增加表前缀支持；
2、修正decimal(5, 2)类型中括号内出现空格导致解析出错的bug；
3、修正xorm解析工具在windows环境下，指定生成路径时model名获取不正确的bug
二、xorm对于数据字段类型为文本类型默认值为空白字符的情况下，生成的struct中default信息丢失的bug，已修正。
