### PR TITLE
Repair Time problem

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -332,16 +332,7 @@ func buildConditions(engine *Engine, table *Table, bean interface{},
 				if !requiredField && (t.IsZero() || !fieldValue.IsValid()) {
 					continue
 				}
-				var str string
-				if col.SQLType.Name == Time {
-					s := t.UTC().Format("2006-01-02 15:04:05")
-					val = s[11:19]
-				} else if col.SQLType.Name == Date {
-					str = t.Format("2006-01-02")
-					val = str
-				} else {
-					val = t
-				}
+				val = engine.FormatTime(col.SQLType.Name, t)
 			} else {
 				engine.autoMapType(fieldValue)
 				if table, ok := engine.Tables[fieldValue.Type()]; ok {

--- a/table.go
+++ b/table.go
@@ -456,7 +456,7 @@ func (table *Table) genCols(session *Session, bean interface{}, useCol bool, inc
 		}
 
 		if (col.IsCreated || col.IsUpdated) && session.Statement.UseAutoTime {
-			args = append(args, time.Now())
+			args = append(args, session.Engine.NowTime(col.SQLType.Name))
 		} else if col.IsVersion && session.Statement.checkVersion {
 			args = append(args, 1)
 		} else {

--- a/xorm.go
+++ b/xorm.go
@@ -20,8 +20,12 @@ func close(engine *Engine) {
 // new a db manager according to the parameter. Currently support four
 // drivers
 func NewEngine(driverName string, dataSourceName string) (*Engine, error) {
-	engine := &Engine{DriverName: driverName,
-		DataSourceName: dataSourceName, Filters: make([]Filter, 0)}
+	engine := &Engine{
+		DriverName:     driverName,
+		DataSourceName: dataSourceName,
+		Filters:        make([]Filter, 0),
+		TimeZone:       "UTC",
+	}
 	engine.SetMapper(SnakeMapper{})
 
 	if driverName == SQLITE {


### PR DESCRIPTION
Repair time problem, increase the time zone setting parameter (engine.TimeZone = "UTC" (default) or engine.TimeZone = "Local". "UTC" may be abbreviated as "U"; "Local" can be abbreviated as "L")
