### PR TITLE
Update xorm.go

### DIFF
--- a/xorm.go
+++ b/xorm.go
@@ -29,6 +29,7 @@ func regDrvsNDialects() bool {
 			getDriver  func() core.Driver
 			getDialect func() core.Dialect
 		}{
+			"mssql":    {"mssql", func() core.Driver { return &odbcDriver{} }, func() core.Dialect { return &mssql{} }},
 			"odbc":     {"mssql", func() core.Driver { return &odbcDriver{} }, func() core.Dialect { return &mssql{} }}, // !nashtsai! TODO change this when supporting MS Access
 			"mysql":    {"mysql", func() core.Driver { return &mysqlDriver{} }, func() core.Dialect { return &mysql{} }},
 			"mymysql":  {"mysql", func() core.Driver { return &mymysqlDriver{} }, func() core.Dialect { return &mysql{} }},


### PR DESCRIPTION
增加对https://github.com/denisenkom/go-mssqldb的支持，go-mssqldb对mssql数据库的支持兼容性较odbc好
