### PR TITLE
bugfix: getting the right column lines

### DIFF
--- a/sqlite3_dialect.go
+++ b/sqlite3_dialect.go
@@ -129,7 +129,7 @@ func (db *sqlite3) GetColumns(tableName string) ([]string, map[string]*core.Colu
 	}
 
 	nStart := strings.Index(name, "(")
-	nEnd := strings.Index(name, ")")
+	nEnd := strings.LastIndex(name, ")")
 	colCreates := strings.Split(name[nStart+1:nEnd], ",")
 	cols := make(map[string]*core.Column)
 	colSeq := make([]string, 0)


### PR DESCRIPTION
getting the right column lines when the culumns type contains varchar (n) or number (n, m)
