### PR TITLE
修复mysql下group by 字段被替换成查询的column的问题

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -1190,7 +1190,7 @@ func (statement *Statement) genSelectSql(columnStr string) (a string) {
 		if columnStr == "" {
 			columnStr = statement.Engine.Quote(strings.Replace(statement.GroupByStr, ",", statement.Engine.Quote(","), -1))
 		}
-		statement.GroupByStr = columnStr
+		//statement.GroupByStr = columnStr
 	}
 	var distinct string
 	if statement.IsDistinct {


### PR DESCRIPTION
修复mysql下 select id,name from user where type=1 group by login_time 被替换成 select id,name from user where type =1 group by id,name的问题