### PR TITLE
bugfix #213

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -933,7 +933,7 @@ func (engine *Engine) mapType(v reflect.Value) *core.Table {
 
 		table.AddColumn(col)
 
-		if fieldType.Kind() == reflect.Int64 && (col.FieldName == "Id" || strings.HasSuffix(col.FieldName, ".Id")) {
+		if fieldType.Kind() == reflect.Int64 && (strings.ToUpper(col.FieldName) == "ID" || strings.HasSuffix(strings.ToUpper(col.FieldName), ".ID")) {
 			idFieldColName = col.Name
 		}
 	} // end for


### PR DESCRIPTION
参考帮助文档 [自动映射的规则](http://gobook.io/read/go-xorm/manual-zh-cn/chapter-02/4.columns.html) 中的说明

> 如果field名称为Id而且类型为int64并且没有定义tag，则会被xorm视为主键，并且拥有自增属性。如果想用Id以外的名字或非int64类型做为主键名，必须在对应的Tag上加上xorm:"pk"来定义主键，加上xorm:"autoincr"作为自增。这里需要注意的是，有些数据库并不允许非主键的自增属性。

因此在使用`core.GonicMapper`时，忽略了ID主键