### PR TITLE
Fix to refer invalid memory access on helpers.go

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -282,7 +282,10 @@ func query2(db *core.DB, sqlStr string, params ...interface{}) (resultsSlice []m
 }
 
 func setColumnTime(bean interface{}, col *core.Column, t time.Time) {
-	v, _ := col.ValueOf(bean)
+	v, err := col.ValueOf(bean)
+	if err != nil {
+		return
+	}
 	if v.CanSet() {
 		switch v.Type().Kind() {
 		case reflect.Struct:


### PR DESCRIPTION
Hi there,

I've got a bug regarding invalid memory access because a passing value has gone when access.

It's occurred from the following commit. (11d36774e9cd90eb22ebd2727868c09928d2702a)

So, I add nil-checked statement.

Thx

(Please check the PR ASAP! :bow: )