### PR TITLE
fix non-int pk issues

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -599,7 +599,9 @@ func buildConditions(engine *Engine, table *core.Table, bean interface{},
 				if table, ok := engine.Tables[fieldValue.Type()]; ok {
 					if len(table.PrimaryKeys) == 1 {
 						pkField := reflect.Indirect(fieldValue).FieldByName(table.PKColumns()[0].FieldName)
-						if pkField.Int() != 0 {
+						// fix non-int pk issues
+						//if pkField.Int() != 0 {
+						if pkField.IsValid() {
 							val = pkField.Interface()
 						} else {
 							continue


### PR DESCRIPTION
package test

import (
	_ "github.com/go-sql-driver/mysql"
	"github.com/go-xorm/xorm"
	"testing"
)

type Model struct {
	Id   int64
	Tags *Tag `xorm:"tag_id varchar(255) index"`
}

type Tag struct {
	Id string `xorm:"pk unique varchar(255)"`
}

func Test_Test(t *testing.T) {
	orm, err := xorm.NewEngine("mysql", "root:GooglE@/test?charset=utf8")
	if err != nil {
		t.Error(err)
	}
	if err = orm.Sync2(new(Model), new(Tag)); err != nil {
		t.Error(err)
	}

	orm.Insert(&Tag{Id: "USA"})
	orm.Insert(&Tag{Id: "UK"})

	orm.Insert(&Model{Tags: &Tag{Id: "USA"}})
	orm.Insert(&Model{Tags: &Tag{Id: "USA"}})
	orm.Insert(&Model{Tags: &Tag{Id: "USA"}})

	orm.Delete(&Model{Tags: &Tag{Id: "USA"}}) // Tag主键为非数字时，此处报错
}
