### PR TITLE
MSSQL: Also use doublequote as quote char to avoid problems

### DIFF
--- a/mssql_dialect.go
+++ b/mssql_dialect.go
@@ -270,7 +270,7 @@ func (db *mssql) IsReserved(name string) bool {
 }
 
 func (db *mssql) Quote(name string) string {
-	return "[" + name + "]"
+	return "\"" + name + "\""
 }
 
 func (db *mssql) QuoteStr() string {


### PR DESCRIPTION
MSSQL: Also use doublequote as quote char to avoid problems.
