### PR TITLE
add Options() to specify query options

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -571,6 +571,13 @@ func (engine *Engine) SetExpr(column string, expression string) *Session {
 	return session.SetExpr(column, expression)
 }
 
+// Method Options specify the query option
+func (engine *Engine) Options(options ...string) *Session {
+	session := engine.NewSession()
+	session.IsAutoClose = true
+	return session.Options(options...)
+}
+
 // Temporarily change the Get, Find, Update's table
 func (engine *Engine) Table(tableNameOrBean interface{}) *Session {
 	session := engine.NewSession()

--- a/session.go
+++ b/session.go
@@ -168,6 +168,12 @@ func (session *Session) SetExpr(column string, expression string) *Session {
 	return session
 }
 
+// Method Options specify the query option
+func (session *Session) Options(options ...string) *Session {
+	session.Statement.Options = options
+	return session
+}
+
 // Method Cols provides some columns to special
 func (session *Session) Cols(columns ...string) *Session {
 	session.Statement.Cols(columns...)
@@ -722,7 +728,7 @@ func (session *Session) cacheGet(bean interface{}, sqlStr string, args ...interf
 func (session *Session) cacheFind(t reflect.Type, sqlStr string, rowsSlicePtr interface{}, args ...interface{}) (err error) {
 	if session.Statement.RefTable == nil ||
 		indexNoCase(sqlStr, "having") != -1 ||
-		indexNoCase(sqlStr, "group by") != -1  ||
+		indexNoCase(sqlStr, "group by") != -1 ||
 		session.Tx != nil {
 		return ErrCacheFailed
 	}

--- a/statement.go
+++ b/statement.go
@@ -69,6 +69,7 @@ type Statement struct {
 	incrColumns   map[string]incrParam
 	decrColumns   map[string]decrParam
 	exprColumns   map[string]exprParam
+	Options       []string
 }
 
 // init
@@ -1305,6 +1306,20 @@ func (statement *Statement) genSelectSql(columnStr string) (a string) {
 	} else if statement.Engine.dialect.DBType() == core.ORACLE {
 		if statement.Start != 0 || statement.LimitN != 0 {
 			a = fmt.Sprintf("SELECT %v FROM (SELECT %v,ROWNUM RN FROM (%v) at WHERE ROWNUM <= %d) aat WHERE RN > %d", columnStr, columnStr, a, statement.Start+statement.LimitN, statement.Start)
+		}
+	}
+
+	if len(statement.Options) > 0 {
+		switch statement.Engine.dialect.DBType() {
+		case core.MYSQL:
+			for _, option := range statement.Options {
+				switch option {
+				case "select:for-update":
+					a += " FOR UPDATE"
+				case "select:lock-in-share-mode":
+					a += " LOCK IN SHARE MODE"
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently two options implemented for MySQL:
- select:for-update
- select:lock-in-share-mode