### PR TITLE
Add feature to update with null for non pointer value

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -553,6 +553,13 @@ func (engine *Engine) Omit(columns ...string) *Session {
 	return session.Omit(columns...)
 }
 
+// Set null when column is zero-value and nullable for update
+func (engine *Engine) Nullable(columns ...string) *Session {
+	session := engine.NewSession()
+	session.IsAutoClose = true
+	return session.Nullable(columns...)
+}
+
 // This method will generate "column IN (?, ?)"
 func (engine *Engine) In(column string, args ...interface{}) *Session {
 	session := engine.NewSession()

--- a/helpers.go
+++ b/helpers.go
@@ -39,6 +39,8 @@ func isZero(k interface{}) bool {
 		return k.(uint64) == 0
 	case string:
 		return k.(string) == ""
+	case time.Time:
+		return k.(time.Time).IsZero()
 	}
 	return false
 }
@@ -353,6 +355,14 @@ func genCols(table *core.Table, session *Session, bean interface{}, useCol bool,
 		if session.Statement.OmitStr != "" {
 			if _, ok := session.Statement.columnMap[lColName]; ok {
 				continue
+			}
+		}
+
+		// !evalphobia! set fieldValue as nil when column is nullable and zero-value
+		if _, ok := session.Statement.nullableMap[lColName]; ok {
+			if col.Nullable && isZero(fieldValue.Interface()) {
+				var nilValue *int
+				fieldValue = reflect.ValueOf(nilValue)
 			}
 		}
 

--- a/session.go
+++ b/session.go
@@ -223,6 +223,12 @@ func (session *Session) Omit(columns ...string) *Session {
 	return session
 }
 
+// Set null when column is zero-value and nullable for update
+func (session *Session) Nullable(columns ...string) *Session {
+	session.Statement.Nullable(columns...)
+	return session
+}
+
 // Method NoAutoTime means do not automatically give created field and updated field
 // the current time on the current session temporarily
 func (session *Session) NoAutoTime() *Session {
@@ -3408,7 +3414,8 @@ func (session *Session) Update(bean interface{}, condiBean ...interface{}) (int6
 		if session.Statement.ColumnStr == "" {
 			colNames, args = buildUpdates(session.Engine, table, bean, false, false,
 				false, false, session.Statement.allUseBool, session.Statement.useAllCols,
-				session.Statement.mustColumnMap, session.Statement.columnMap, true)
+				session.Statement.mustColumnMap, session.Statement.nullableMap, 
+				session.Statement.columnMap, true)
 		} else {
 			colNames, args, err = genCols(table, session, bean, true, true)
 			if err != nil {


### PR DESCRIPTION
This PR added method `Nullable()` to add null valued colums for UPDATE.

For INSERT, we can insert null value using `Omit()`, but not for UPDATE.

So using `Nullbale()` and set columns which could be null value,
null value is set when the value is `zero-value` and `nullable`.

For example, use like below,

```go
type Example struct {
    Id     int64     `xorm:"pk"`
    Field1 string    `xorm:"default null"`
    Field2 int64     `xorm:"default null"`
    Field3 time.Time `xorm:"default null"`
    NoNull int64     `xorm:"not null"`
}

func example(){
    row := &Example{}
    session := engine.NewSession()
    defer session.Close()    // * updated 2015-06-11

    session.
        Where("id = ?", id).
        Nullable("field1").
        Update(row)
    // => UPDATE example SET field1 = null WHERE id = ?

    session.
        Where("id = ?", id).
        Cols("field1", "field2", "field3").
        Nullable("field1", "field3").
        Update(row)
    // => UPDATE example SET field1 = null, field3 = null WHERE id = ?


    session.
        Where("id = ?", id).
        Nullable("field1", "no_null").
        Update(row)
    // => UPDATE example SET field1 = null WHERE id = ?

}
```

If anything weird or preferable way, I gonna fix it.
