### PR TITLE
Added feature for storing lastSQL query on session

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -45,7 +45,7 @@ func newRows(session *Session, bean interface{}) (*Rows, error) {
 		sqlStr = filter.Do(sqlStr, session.Engine.dialect, rows.session.Statement.RefTable)
 	}
 
-	rows.session.Engine.logSQL(sqlStr, args)
+	rows.session.saveLastSQL(sqlStr, args)
 	var err error
 	rows.stmt, err = rows.session.DB().Prepare(sqlStr)
 	if err != nil {


### PR DESCRIPTION
This PR added method `LastSQL()` and `saveLastSQL()` to get and store information of last query on the session.
To achieve this, `session.Engine.logSQL()` is moved into  `session.saveLastSQL()`.
