### PR TITLE
Modified time.IsZero() to use interface

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -15,6 +15,10 @@ import (
 	"github.com/go-xorm/core"
 )
 
+type zeroable interface {
+	IsZero() bool
+}
+
 func isZero(k interface{}) bool {
 	switch k.(type) {
 	case int:
@@ -45,8 +49,8 @@ func isZero(k interface{}) bool {
 		return k.(bool) == false
 	case string:
 		return k.(string) == ""
-	case time.Time:
-		return k.(time.Time).IsZero()
+	case zeroable:
+		return k.(zeroable).IsZero()
 	}
 	return false
 }


### PR DESCRIPTION
This PR changed checking zero-value for struct to use `IsZero() bool` in `isZero()` helper function.
Every struct which has `IsZero() bool` can be evaluated as zero-value or not.
This is useful when using custom time struct for time field.