### PR TITLE
Added statement.RawCols()

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -541,6 +541,12 @@ func (engine *Engine) Cols(columns ...string) *Session {
 	return session.Cols(columns...)
 }
 
+func (engine *Engine) RawCols(columns ...string) *Session {
+	session := engine.NewSession()
+	session.IsAutoClose = true
+	return session.RawCols(columns...)
+}
+
 func (engine *Engine) AllCols() *Session {
 	session := engine.NewSession()
 	session.IsAutoClose = true

--- a/session.go
+++ b/session.go
@@ -201,6 +201,12 @@ func (session *Session) Cols(columns ...string) *Session {
 	return session
 }
 
+// Method RawCols adds Cols without quotes
+func (session *Session) RawCols(columns ...string) *Session {
+	session.Statement.RawCols(columns...)
+	return session
+}
+
 func (session *Session) AllCols() *Session {
 	session.Statement.AllCols()
 	return session

--- a/statement.go
+++ b/statement.go
@@ -864,6 +864,16 @@ func (statement *Statement) Cols(columns ...string) *Statement {
 	return statement
 }
 
+// Generate "col1, col2" statement without quotes
+func (statement *Statement) RawCols(columns ...string) *Statement {
+	newColumns := col2NewCols(columns...)
+	for _, nc := range newColumns {
+		statement.columnMap[strings.ToLower(nc)] = true
+	}
+	statement.ColumnStr = strings.Join(newColumns, ", ")
+	return statement
+}
+
 // Update use only: update all columns
 func (statement *Statement) AllCols() *Statement {
 	statement.useAllCols = true


### PR DESCRIPTION
This PR adds `statement.RawCols` method, which enables to use `raw columns` in SELECT statement.
Then we can use `COUNT`, `MAX` and `AS` with  other helper methods, see below example code

```go
// normal table row
type Food struct {
    Name    string
    Country string
    Spicy   int64
}

// used for aggregate query
type FoodGroup struct {
    Country string
    Count   int64
}

var s Session

func CountByCountry(){
    s.RawCols("country", "count(*) AS count")
    s.GroupBy("country")
    s.And("spicy > ?", 1)
    
    list := []*FoodGroup{}
    err := s.Find(&list)
    if err != nil {
        panic(err.Error())
    }

    fmt.Println(list)
}

```

(`raw` means like `unescaped` and `without quotation`)