### PR TITLE
Preventing the creation of duplicate index TokuDB

### DIFF
--- a/mysql_dialect.go
+++ b/mysql_dialect.go
@@ -411,7 +411,7 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*core.Column
 func (db *mysql) GetTables() ([]*core.Table, error) {
 	args := []interface{}{db.DbName}
 	s := "SELECT `TABLE_NAME`, `ENGINE`, `TABLE_ROWS`, `AUTO_INCREMENT` from " +
-		"`INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=? AND (`ENGINE`='MyISAM' OR `ENGINE` = 'InnoDB')"
+		"`INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=? AND (`ENGINE`='MyISAM' OR `ENGINE` = 'InnoDB' OR `ENGINE` = 'TokuDB')"
 	db.LogSQL(s, args)
 
 	rows, err := db.DB().Query(s, args...)


### PR DESCRIPTION
Fail to initialize ORM engine: sync database struct error: Error 1061: Duplicate key name …

Supported DBMS:
* Percona-Server 5.6
* MariaDB 5.5/10.0/10.1

```
+--------+--------------+------+------------+---------+--------------------------------------------------------------------------------------------------+
| Engine | Transactions | XA   | Savepoints | Support | Comment                                                                                          |
+--------+--------------+------+------------+---------+--------------------------------------------------------------------------------------------------+
| TokuDB | YES          | YES  | YES        | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology                                   |
| InnoDB | YES          | YES  | YES        | DEFAULT | Percona-XtraDB, Supports transactions, row-level locking, foreign keys and encryption for tables |
+--------+--------------+------+------------+---------+--------------------------------------------------------------------------------------------------+
```