### PR TITLE
quote "."(periods) in column name.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -139,7 +139,7 @@ func (engine *Engine) quoteColumn(keyName string) string {
 	keyName = strings.Replace(keyName, "`", "", -1)
 	keyName = strings.Replace(keyName, engine.QuoteStr(), "", -1)
 
-	keyName = strings.Replace(keyName, ",", engine.dialect.QuoteStr()+","+engine.dialect.QuoteStr(), -1)
+	keyName = strings.Replace(keyName, ".", engine.dialect.QuoteStr()+"."+engine.dialect.QuoteStr(), -1)
 
 	return engine.dialect.QuoteStr() + keyName + engine.dialect.QuoteStr()
 }

--- a/engine.go
+++ b/engine.go
@@ -139,6 +139,7 @@ func (engine *Engine) quoteColumn(keyName string) string {
 	keyName = strings.Replace(keyName, "`", "", -1)
 	keyName = strings.Replace(keyName, engine.QuoteStr(), "", -1)
 
+	keyName = strings.Replace(keyName, ",", engine.dialect.QuoteStr()+","+engine.dialect.QuoteStr(), -1)
 	keyName = strings.Replace(keyName, ".", engine.dialect.QuoteStr()+"."+engine.dialect.QuoteStr(), -1)
 
 	return engine.dialect.QuoteStr() + keyName + engine.dialect.QuoteStr()


### PR DESCRIPTION
Correctly handle columns being passed in the format
"table.column"
 fixes #369 