### PR TITLE
Always generate column names, don't use * even if join

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -929,8 +929,16 @@ func (engine *Engine) mapType(v reflect.Value) *core.Table {
 		fieldType := fieldValue.Type()
 
 		if ormTagStr != "" {
-			col = &core.Column{FieldName: t.Field(i).Name, Nullable: true, IsPrimaryKey: false,
-				IsAutoIncrement: false, MapType: core.TWOSIDES, Indexes: make(map[string]bool)}
+			col = &core.Column{
+				FieldName:       t.Field(i).Name,
+				TableName:       table.Name,
+				Nullable:        true,
+				IsPrimaryKey:    false,
+				IsAutoIncrement: false,
+				MapType:         core.TWOSIDES,
+				Indexes:         make(map[string]bool),
+			}
+
 			tags := splitTag(ormTagStr)
 
 			if len(tags) > 0 {
@@ -952,6 +960,11 @@ func (engine *Engine) mapType(v reflect.Value) *core.Table {
 					case reflect.Struct:
 						parentTable := engine.mapType(fieldValue)
 						for _, col := range parentTable.Columns() {
+							if t.Field(i).Anonymous {
+								col.TableName = parentTable.Name
+							} else {
+								col.TableName = engine.TableMapper.Obj2Table(t.Field(i).Name)
+							}
 							col.FieldName = fmt.Sprintf("%v.%v", t.Field(i).Name, col.FieldName)
 							table.AddColumn(col)
 						}
@@ -1133,6 +1146,7 @@ func (engine *Engine) mapType(v reflect.Value) *core.Table {
 			col = core.NewColumn(engine.ColumnMapper.Obj2Table(t.Field(i).Name),
 				t.Field(i).Name, sqlType, sqlType.DefaultLength,
 				sqlType.DefaultLength2, true)
+			col.TableName = table.Name
 		}
 		if col.IsAutoIncrement {
 			col.Nullable = false

--- a/session.go
+++ b/session.go
@@ -1173,9 +1173,9 @@ func (session *Session) Find(rowsSlicePtr interface{}, condiBean ...interface{})
 		// See https://github.com/go-xorm/xorm/issues/179
 		if col := table.DeletedColumn(); col != nil && !session.Statement.unscoped {
 			// tag "deleted" is enabled
-			var colName = session.Statement.colName(col, session.Statement.TableName())
-			session.Statement.ConditionStr = fmt.Sprintf("(%v IS NULL OR %v = '0001-01-01 00:00:00')",
-				colName, colName)
+			var colName = session.Statement.colName(col)
+			session.Statement.ConditionStr = fmt.Sprintf(
+				"(%v IS NULL OR %v = '0001-01-01 00:00:00')", colName, colName)
 		}
 	}
 


### PR DESCRIPTION
With these changes, SELECT always lists column names, even with JOINs,
instead of using `SELECT *`.

This also eliminates xorm warnings "table FOO has no column BAR" appearing when xorm uses `SELECT *` and retrieves  superfluous fields.

**Changelog**

* go-xorm/core#13: add new field `Column.TableName` and fill it when creating column in `mapType()`
* add new field `Statement.OutTable` and fill it in `Get()` and `Find()`
* add `buildColName()` function and `colName()` wrapper that uses `Column.TableName` if available or default table name otherwise, and use them everywhere
* move all column string related code to `genColumnStr()` and use it everywhere
* go-xorm/tests#11: add more tests for extends

**OutTable**

Unlike `RefTable`, `OutTable` will always contain *output* table.

E.g. in this case:

```go
type ResultTable struct {
    SomeTable    `xorm:"extends"`
    AnotherTable `xorm:"extends"`
}
result := ResultTable{}
engine.Table(&SomeTable{}).Where(...).Join(...).Get(&result)
```

* `RefTable` will contain `SomeTable`
* `OutTable` will contain `ResultTable`

We need `ResultTable` to generate column string for all required fields when using `Table()` and `Join()` together.

I don't know if we can just overwrite `RefTable` with output table in `Get()` or `Find()`, so I introduced new field. Let me know if there's a better way to do it.