### PR TITLE
Smarter field qualifying algorithm

### DIFF
--- a/session.go
+++ b/session.go
@@ -1140,7 +1140,8 @@ func (session *Session) Find(rowsSlicePtr interface{}, condiBean ...interface{})
 		// See https://github.com/go-xorm/xorm/issues/179
 		if col := table.DeletedColumn(); col != nil && !session.Statement.unscoped {
 			// tag "deleted" is enabled
-			var colName = session.Statement.colName(col)
+			colName, _ := session.Statement.colName(
+				col, session.Statement.aliasedTableName())
 			session.Statement.ConditionStr = fmt.Sprintf(
 				"(%v IS NULL OR %v = '0001-01-01 00:00:00')", colName, colName)
 		}


### PR DESCRIPTION
This PR implements smarter algorithm for field qualifier, discussed in #387.

New algorithm tries all struct type/field names, recursively for nested structs. Additional syntax for named extends (`xorm:"extends(name)"`) is **not** implemented yet.

Two related PRs:
* go-xorm/core#14
* go-xorm/tests#13 (much more extends tests for various tricky cases)