### PR TITLE
Fixed driver-name logging

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -239,7 +239,7 @@ func (engine *Engine) Close() error {
 func (engine *Engine) Ping() error {
 	session := engine.NewSession()
 	defer session.Close()
-	engine.logger.Info("PING DATABASE", engine.DriverName)
+	engine.logger.Infof("PING DATABASE %v", engine.DriverName())
 	return session.Ping()
 }
 


### PR DESCRIPTION
@lunny 

logging of a function pointer is not human-friendly.

```bash
[xorm] [info]  2016/05/23 02:26:29.734657 PING DATABASE0x4647d0
```

So, I fixed.

```bash
[xorm] [info]  2016/05/23 02:31:12.277675 PING DATABASE mysql
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-xorm/xorm/399)
<!-- Reviewable:end -->
