### PR TITLE
Allow the database's timezone to be specified. 

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -41,6 +41,7 @@ type Engine struct {
 
 	logger     core.ILogger
 	TZLocation *time.Location
+	DatabaseTZ *time.Location // The timezone of the database
 
 	disableGlobalCache bool
 }

--- a/session.go
+++ b/session.go
@@ -1816,9 +1816,13 @@ func (session *Session) _row2Bean(rows *core.Rows, fields []string, fieldsCount 
 						t := vv.Convert(core.TimeType).Interface().(time.Time)
 						z, _ := t.Zone()
 						if len(z) == 0 || t.Year() == 0 { // !nashtsai! HACK tmp work around for lib/pq doesn't properly time with location
+							dbTZ := session.Engine.DatabaseTZ
+							if dbTZ == nil {
+								dbTZ = time.Local
+							}
 							session.Engine.logger.Debugf("empty zone key[%v] : %v | zone: %v | location: %+v\n", key, t, z, *t.Location())
 							t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(),
-								t.Minute(), t.Second(), t.Nanosecond(), time.Local)
+								t.Minute(), t.Second(), t.Nanosecond(), dbTZ)
 						}
 						// !nashtsai! convert to engine location
 						if col.TimeZone == nil {


### PR DESCRIPTION
This fixes a problem with timezone conversion when the database's timezone differs from the xorm client's timezone.

See https://github.com/go-xorm/xorm/issues/419
