### PR TITLE
Allow a struct to be used as a field with jsonb

### DIFF
--- a/session.go
+++ b/session.go
@@ -3042,7 +3042,9 @@ func (session *Session) value2Interface(col *core.Column, fieldValue reflect.Val
 				pkField := reflect.Indirect(fieldValue).FieldByName(fieldTable.PKColumns()[0].FieldName)
 				return pkField.Interface(), nil
 			}
-			return 0, fmt.Errorf("no primary key for col %v", col.Name)
+			if fieldTable.Type == nil {
+				return 0, fmt.Errorf("no primary key for col %v", col.Name)
+			}
 		}
 
 		if col.SQLType.IsText() {


### PR DESCRIPTION
Hi @lunny,

This addresses #411 where you can't use a struct as a field with jsonb. It checks if the `Type` property is set to nil before returning with an error. An example of what that object looks like:

```
(*core.Table)(0xc8200165a0)({
 Name: (string) (len=7) "address",
 Type: (*reflect.rtype)(0x401d40)(main.Address),
 columnsSeq: ([]string) (len=2 cap=2) {
  (string) (len=6) "street",
  (string) (len=4) "city"
 },
...
```

where `Address` is the name of the struct.

The change allows it to fall through the `if !col.SQLType.IsJson() {` block and handled a few lines down in `else if col.SQLType.IsBlob() {`

Tests all pass as well, but please let me know if the change is not as trivial as this (as you had mentioned this was a new feature request). Thanks!