### PR TITLE
Apply the given location instead of engine.location

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1599,6 +1599,8 @@ func (engine *Engine) formatTime(tz *time.Location, sqlTypeName string, t time.T
 		return t
 	}
 	if tz != nil {
+		t = t.In(tz)
+	} else {
 		t = engine.TZTime(t)
 	}
 	switch sqlTypeName {


### PR DESCRIPTION
I fixed a bug which ignores the given `*time.Location` by argument of the following function;

``` go
func (engine *Engine) formatTime(tz *time.Location, sqlTypeName string, t time.Time) (v interface{}) {
    // ...
    if tz != nil {
        t = engine.TZTime(t)
    }
```

The above code has no meanings of `tz`. So, I did add some code to handle `tz` correctly.

``` go
    if tz != nil {
+       t = t.In(tz)
+   } else {
        t = engine.TZTime(t)
    }
```

It has a tiny bug that happened when I try to switch timezone in my app.

see also;

``` go
func (engine *Engine) formatColTime(col *core.Column, t time.Time) (v interface{}) {
    if col.DisableTimeZone {
        return engine.formatTime(nil, col.SQLType.Name, t)
    } else if col.TimeZone != nil {
        return engine.formatTime(col.TimeZone, col.SQLType.Name, t)
    }
    return engine.formatTime(engine.TZLocation, col.SQLType.Name, t)
}
```

thx
