### PR TITLE
Using uuid with mssql

### DIFF
--- a/mssql_dialect.go
+++ b/mssql_dialect.go
@@ -247,6 +247,9 @@ func (db *mssql) SqlType(c *core.Column) string {
 		res = core.Text
 	case core.Double:
 		res = core.Real
+	case core.Uuid:
+		res = core.Varchar
+		c.Length = 40
 	default:
 		res = t
 	}


### PR DESCRIPTION
Using uuid with mssql results in an error, that the type uuid can not be found by mssql. This is resolved by mapping uuid to varchar.