### PR TITLE
Columns string generation via bytes.Buffer (statement.genColumnStr)

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -124,27 +124,47 @@ func (engine *Engine) QuoteStr() string {
 }
 
 // Quote Use QuoteStr quote the string sql
-func (engine *Engine) Quote(sql string) string {
-	return engine.quoteTable(sql)
+func (engine *Engine) Quote(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) == 0 {
+		return value
+	}
+
+	if string(value[0]) == engine.dialect.QuoteStr() || value[0] == '`' {
+		return value
+	}
+
+	value = strings.Replace(value, ".", engine.dialect.QuoteStr()+"."+engine.dialect.QuoteStr(), -1)
+
+	return engine.dialect.QuoteStr() + value + engine.dialect.QuoteStr()
+}
+
+// QuoteTo quotes string and writes into the buffer
+func (engine *Engine) QuoteTo(buf *bytes.Buffer, value string) {
+
+	if buf == nil {
+		return
+	}
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+
+	if string(value[0]) == engine.dialect.QuoteStr() || value[0] == '`' {
+		buf.WriteString(value)
+		return
+	}
+
+	value = strings.Replace(value, ".", engine.dialect.QuoteStr()+"."+engine.dialect.QuoteStr(), -1)
+
+	buf.WriteString(engine.dialect.QuoteStr())
+	buf.WriteString(value)
+	buf.WriteString(engine.dialect.QuoteStr())
 }
 
 func (engine *Engine) quote(sql string) string {
 	return engine.dialect.QuoteStr() + sql + engine.dialect.QuoteStr()
-}
-
-func (engine *Engine) quoteTable(keyName string) string {
-	keyName = strings.TrimSpace(keyName)
-	if len(keyName) == 0 {
-		return keyName
-	}
-
-	if string(keyName[0]) == engine.dialect.QuoteStr() || keyName[0] == '`' {
-		return keyName
-	}
-
-	keyName = strings.Replace(keyName, ".", engine.dialect.QuoteStr()+"."+engine.dialect.QuoteStr(), -1)
-
-	return engine.dialect.QuoteStr() + keyName + engine.dialect.QuoteStr()
 }
 
 // SqlType will be depracated, please use SQLType instead

--- a/statement.go
+++ b/statement.go
@@ -989,9 +989,8 @@ func (statement *Statement) genColumnStr() string {
 	var buf bytes.Buffer
 
 	columns := statement.RefTable.Columns()
-	columnsCount := len(columns)
 
-	for ndx, col := range columns {
+	for _, col := range columns {
 
 		if statement.OmitStr != "" {
 			if _, ok := statement.columnMap[strings.ToLower(col.Name)]; ok {
@@ -1001,6 +1000,10 @@ func (statement *Statement) genColumnStr() string {
 
 		if col.MapType == core.ONLYTODB {
 			continue
+		}
+
+		if buf.Len() != 0 {
+			buf.WriteString(", ")
 		}
 
 		if col.IsPrimaryKey && statement.Engine.Dialect().DBType() == "ql" {
@@ -1018,10 +1021,6 @@ func (statement *Statement) genColumnStr() string {
 		}
 
 		statement.Engine.QuoteTo(&buf, col.Name)
-
-		if ndx < columnsCount-1 {
-			buf.WriteString(", ")
-		}
 	}
 
 	return buf.String()

--- a/statement_test.go
+++ b/statement_test.go
@@ -18,6 +18,8 @@ var colStrTests = []struct {
 	{"Code2", -1, "`ID`, `IsDeleted`, `Caption`, `Code1`, `Code3`, `ParentID`, `Latitude`, `Longitude`"},
 	{"", 1, "`ID`, `Caption`, `Code1`, `Code2`, `Code3`, `ParentID`, `Latitude`, `Longitude`"},
 	{"Code3", 1, "`ID`, `Caption`, `Code1`, `Code2`, `ParentID`, `Latitude`, `Longitude`"},
+	{"Longitude", 1, "`ID`, `Caption`, `Code1`, `Code2`, `Code3`, `ParentID`, `Latitude`"},
+	{"", 8, "`ID`, `IsDeleted`, `Caption`, `Code1`, `Code2`, `Code3`, `ParentID`, `Latitude`"},
 }
 
 // !nemec784! Only for Statement object creation

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,0 +1,137 @@
+package xorm
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-xorm/core"
+)
+
+var colStrTests = []struct {
+	omitColumn        string
+	onlyToDBColumnNdx int
+	expected          string
+}{
+	{"", -1, "`ID`, `IsDeleted`, `Caption`, `Code1`, `Code2`, `Code3`, `ParentID`, `Latitude`, `Longitude`"},
+	{"Code2", -1, "`ID`, `IsDeleted`, `Caption`, `Code1`, `Code3`, `ParentID`, `Latitude`, `Longitude`"},
+	{"", 1, "`ID`, `Caption`, `Code1`, `Code2`, `Code3`, `ParentID`, `Latitude`, `Longitude`"},
+	{"Code3", 1, "`ID`, `Caption`, `Code1`, `Code2`, `ParentID`, `Latitude`, `Longitude`"},
+}
+
+// !nemec784! Only for Statement object creation
+const driverName = "mysql"
+const dataSourceName = "Server=TestServer;Database=TestDB;Uid=testUser;Pwd=testPassword;"
+
+func init() {
+	core.RegisterDriver(driverName, &mysqlDriver{})
+}
+
+func TestColumnsStringGeneration(t *testing.T) {
+
+	var statement *Statement
+
+	for ndx, testCase := range colStrTests {
+
+		statement = createTestStatement()
+
+		if testCase.omitColumn != "" {
+			statement.Omit(testCase.omitColumn) // !nemec784! Column must be skipped
+		}
+
+		if testCase.onlyToDBColumnNdx >= 0 {
+			columns := statement.RefTable.Columns()
+			columns[testCase.onlyToDBColumnNdx].MapType = core.ONLYTODB // !nemec784! Column must be skipped
+		}
+
+		actual := statement.genColumnStr()
+
+		if actual != testCase.expected {
+			t.Errorf("[test #%d] Unexpected columns string:\nwant:\t%s\nhave:\t%s", ndx, testCase.expected, actual)
+		}
+	}
+}
+
+func BenchmarkColumnsStringGeneration(b *testing.B) {
+
+	b.StopTimer()
+
+	statement := createTestStatement()
+
+	testCase := colStrTests[0]
+
+	if testCase.omitColumn != "" {
+		statement.Omit(testCase.omitColumn) // !nemec784! Column must be skipped
+	}
+
+	if testCase.onlyToDBColumnNdx >= 0 {
+		columns := statement.RefTable.Columns()
+		columns[testCase.onlyToDBColumnNdx].MapType = core.ONLYTODB // !nemec784! Column must be skipped
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		actual := statement.genColumnStr()
+
+		if actual != testCase.expected {
+			b.Errorf("Unexpected columns string:\nwant:\t%s\nhave:\t%s", testCase.expected, actual)
+		}
+	}
+}
+
+type TestType struct {
+	ID        int64   `xorm:"ID PK"`
+	IsDeleted bool    `xorm:"IsDeleted"`
+	Caption   string  `xorm:"Caption"`
+	Code1     string  `xorm:"Code1"`
+	Code2     string  `xorm:"Code2"`
+	Code3     string  `xorm:"Code3"`
+	ParentID  int64   `xorm:"ParentID"`
+	Latitude  float64 `xorm:"Latitude"`
+	Longitude float64 `xorm:"Longitude"`
+}
+
+func (TestType) TableName() string {
+	return "TestTable"
+}
+
+func createTestStatement() *Statement {
+
+	engine := createTestEngine()
+
+	statement := &Statement{}
+	statement.Init()
+	statement.Engine = engine
+	statement.setRefValue(reflect.ValueOf(TestType{}))
+
+	return statement
+}
+
+func createTestEngine() *Engine {
+	driver := core.QueryDriver(driverName)
+	uri, err := driver.Parse(driverName, dataSourceName)
+
+	if err != nil {
+		panic(err)
+	}
+
+	dialect := &mysql{}
+	err = dialect.Init(nil, uri, driverName, dataSourceName)
+
+	if err != nil {
+		panic(err)
+	}
+
+	engine := &Engine{
+		dialect:       dialect,
+		Tables:        make(map[reflect.Type]*core.Table),
+		mutex:         &sync.RWMutex{},
+		TagIdentifier: "xorm",
+		TZLocation:    time.Local,
+	}
+	engine.SetMapper(core.NewCacheMapper(new(core.SnakeMapper)))
+
+	return engine
+}


### PR DESCRIPTION
Rewritten `statement.genColumnStr` for columns string generation via `bytes.Buffer` instead of `strings.Join`

Up to 30% faster, 50% less memory usage and 5 times less allocations per operation (see benchmarks below).

Affects on `session.Find` and `session.Get` on simple queries (i.e. without GroupBy and Join).
<br>

Benchmarks (9 columns):
```
BenchmarkColumnsStringGeneration_Join-4		500000	      2748 ns/op    	 784 B/op	      16 allocs/op
BenchmarkColumnsStringGeneration_Buffer-4      1000000	      1941 ns/op    	 352 B/op	       3 allocs/op
```