### PR TITLE
Fix go vet warnings

### DIFF
--- a/examples/sync.go
+++ b/examples/sync.go
@@ -60,7 +60,7 @@ func main() {
 	engines := []engineFunc{postgresEngine}
 	for _, enginefunc := range engines {
 		Orm, err := enginefunc()
-		fmt.Println("--------", Orm.DriverName, "----------")
+		fmt.Println("--------", Orm.DriverName(), "----------")
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/mssql_dialect.go
+++ b/mssql_dialect.go
@@ -371,14 +371,14 @@ func (db *mssql) GetColumns(tableName string) ([]string, map[string]*core.Column
 		}
 		switch ct {
 		case "DATETIMEOFFSET":
-			col.SQLType = core.SQLType{core.TimeStampz, 0, 0}
+			col.SQLType = core.SQLType{Name: core.TimeStampz, DefaultLength: 0, DefaultLength2: 0}
 		case "NVARCHAR":
-			col.SQLType = core.SQLType{core.NVarchar, 0, 0}
+			col.SQLType = core.SQLType{Name: core.NVarchar, DefaultLength: 0, DefaultLength2: 0}
 		case "IMAGE":
-			col.SQLType = core.SQLType{core.VarBinary, 0, 0}
+			col.SQLType = core.SQLType{Name: core.VarBinary, DefaultLength: 0, DefaultLength2: 0}
 		default:
 			if _, ok := core.SqlTypes[ct]; ok {
-				col.SQLType = core.SQLType{ct, 0, 0}
+				col.SQLType = core.SQLType{Name: ct, DefaultLength: 0, DefaultLength2: 0}
 			} else {
 				return nil, nil, errors.New(fmt.Sprintf("unknow colType %v for %v - %v",
 					ct, tableName, col.Name))

--- a/mysql_dialect.go
+++ b/mysql_dialect.go
@@ -373,7 +373,7 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*core.Column
 		col.Length = len1
 		col.Length2 = len2
 		if _, ok := core.SqlTypes[colType]; ok {
-			col.SQLType = core.SQLType{colType, len1, len2}
+			col.SQLType = core.SQLType{Name: colType, DefaultLength: len1, DefaultLength2: len2}
 		} else {
 			return nil, nil, errors.New(fmt.Sprintf("unkonw colType %v", colType))
 		}

--- a/oracle_dialect.go
+++ b/oracle_dialect.go
@@ -733,23 +733,23 @@ func (db *oracle) GetColumns(tableName string) ([]string, map[string]*core.Colum
 
 		switch dt {
 		case "VARCHAR2":
-			col.SQLType = core.SQLType{core.Varchar, len1, len2}
+			col.SQLType = core.SQLType{Name: core.Varchar, DefaultLength: len1, DefaultLength2: len2}
 		case "NVARCHAR2":
-			col.SQLType = core.SQLType{core.NVarchar, len1, len2}
+			col.SQLType = core.SQLType{Name: core.NVarchar, DefaultLength: len1, DefaultLength2: len2}
 		case "TIMESTAMP WITH TIME ZONE":
-			col.SQLType = core.SQLType{core.TimeStampz, 0, 0}
+			col.SQLType = core.SQLType{Name: core.TimeStampz, DefaultLength: 0, DefaultLength2: 0}
 		case "NUMBER":
-			col.SQLType = core.SQLType{core.Double, len1, len2}
+			col.SQLType = core.SQLType{Name: core.Double, DefaultLength: len1, DefaultLength2: len2}
 		case "LONG", "LONG RAW":
-			col.SQLType = core.SQLType{core.Text, 0, 0}
+			col.SQLType = core.SQLType{Name: core.Text, DefaultLength: 0, DefaultLength2: 0}
 		case "RAW":
-			col.SQLType = core.SQLType{core.Binary, 0, 0}
+			col.SQLType = core.SQLType{Name: core.Binary, DefaultLength: 0, DefaultLength2: 0}
 		case "ROWID":
-			col.SQLType = core.SQLType{core.Varchar, 18, 0}
+			col.SQLType = core.SQLType{Name: core.Varchar, DefaultLength: 18, DefaultLength2: 0}
 		case "AQ$_SUBSCRIBERS":
 			ignore = true
 		default:
-			col.SQLType = core.SQLType{strings.ToUpper(dt), len1, len2}
+			col.SQLType = core.SQLType{Name: strings.ToUpper(dt), DefaultLength: len1, DefaultLength2: len2}
 		}
 
 		if ignore {
@@ -842,5 +842,5 @@ func (db *oracle) GetIndexes(tableName string) (map[string]*core.Index, error) {
 }
 
 func (db *oracle) Filters() []core.Filter {
-	return []core.Filter{&core.QuoteFilter{}, &core.SeqFilter{":", 1}, &core.IdFilter{}}
+	return []core.Filter{&core.QuoteFilter{}, &core.SeqFilter{Prefix: ":", Start: 1}, &core.IdFilter{}}
 }

--- a/postgres_dialect.go
+++ b/postgres_dialect.go
@@ -973,21 +973,21 @@ WHERE c.relkind = 'r'::char AND c.relname = $1 AND s.table_schema = $2 AND f.att
 
 		switch dataType {
 		case "character varying", "character":
-			col.SQLType = core.SQLType{core.Varchar, 0, 0}
+			col.SQLType = core.SQLType{Name: core.Varchar, DefaultLength: 0, DefaultLength2: 0}
 		case "timestamp without time zone":
-			col.SQLType = core.SQLType{core.DateTime, 0, 0}
+			col.SQLType = core.SQLType{Name: core.DateTime, DefaultLength: 0, DefaultLength2: 0}
 		case "timestamp with time zone":
-			col.SQLType = core.SQLType{core.TimeStampz, 0, 0}
+			col.SQLType = core.SQLType{Name: core.TimeStampz, DefaultLength: 0, DefaultLength2: 0}
 		case "double precision":
-			col.SQLType = core.SQLType{core.Double, 0, 0}
+			col.SQLType = core.SQLType{Name: core.Double, DefaultLength: 0, DefaultLength2: 0}
 		case "boolean":
-			col.SQLType = core.SQLType{core.Bool, 0, 0}
+			col.SQLType = core.SQLType{Name: core.Bool, DefaultLength: 0, DefaultLength2: 0}
 		case "time without time zone":
-			col.SQLType = core.SQLType{core.Time, 0, 0}
+			col.SQLType = core.SQLType{Name: core.Time, DefaultLength: 0, DefaultLength2: 0}
 		case "oid":
-			col.SQLType = core.SQLType{core.BigInt, 0, 0}
+			col.SQLType = core.SQLType{Name: core.BigInt, DefaultLength: 0, DefaultLength2: 0}
 		default:
-			col.SQLType = core.SQLType{strings.ToUpper(dataType), 0, 0}
+			col.SQLType = core.SQLType{Name: strings.ToUpper(dataType), DefaultLength: 0, DefaultLength2: 0}
 		}
 		if _, ok := core.SqlTypes[col.SQLType.Name]; !ok {
 			return nil, nil, errors.New(fmt.Sprintf("unknow colType: %v", dataType))
@@ -1087,5 +1087,5 @@ func (db *postgres) GetIndexes(tableName string) (map[string]*core.Index, error)
 }
 
 func (db *postgres) Filters() []core.Filter {
-	return []core.Filter{&core.IdFilter{}, &core.QuoteFilter{}, &core.SeqFilter{"$", 1}}
+	return []core.Filter{&core.IdFilter{}, &core.QuoteFilter{}, &core.SeqFilter{Prefix: "$", Start: 1}}
 }

--- a/sqlite3_dialect.go
+++ b/sqlite3_dialect.go
@@ -319,7 +319,7 @@ func (db *sqlite3) GetColumns(tableName string) ([]string, map[string]*core.Colu
 				col.Name = strings.Trim(field, "`[] ")
 				continue
 			} else if idx == 1 {
-				col.SQLType = core.SQLType{field, 0, 0}
+				col.SQLType = core.SQLType{Name: field, DefaultLength: 0, DefaultLength2: 0}
 			}
 			switch field {
 			case "PRIMARY":


### PR DESCRIPTION
Fixed following go vet warnings:
```
$ go vet -v ./...
mssql_dialect.go:374: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
mssql_dialect.go:376: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
mssql_dialect.go:378: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
mssql_dialect.go:381: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
mysql_dialect.go:376: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:736: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:738: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:740: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:742: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:744: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:746: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:748: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:752: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
oracle_dialect.go:845: github.com/go-xorm/core.SeqFilter composite literal uses unkeyed fields
postgres_dialect.go:976: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:978: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:980: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:982: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:984: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:986: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:988: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:990: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
postgres_dialect.go:1090: github.com/go-xorm/core.SeqFilter composite literal uses unkeyed fields
sqlite3_dialect.go:322: github.com/go-xorm/core.SQLType composite literal uses unkeyed fields
exit status 1
examples/sync.go:63: arg Orm.DriverName in Println call is a function value, not a function call
exit status 1
```