### PR TITLE
golint: replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)

### DIFF
--- a/mssql_dialect.go
+++ b/mssql_dialect.go
@@ -5,7 +5,6 @@
 package xorm
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -380,8 +379,7 @@ func (db *mssql) GetColumns(tableName string) ([]string, map[string]*core.Column
 			if _, ok := core.SqlTypes[ct]; ok {
 				col.SQLType = core.SQLType{Name: ct, DefaultLength: 0, DefaultLength2: 0}
 			} else {
-				return nil, nil, errors.New(fmt.Sprintf("unknow colType %v for %v - %v",
-					ct, tableName, col.Name))
+				return nil, nil, fmt.Errorf("Unknown colType %v for %v - %v", ct, tableName, col.Name)
 			}
 		}
 

--- a/mysql_dialect.go
+++ b/mysql_dialect.go
@@ -6,7 +6,6 @@ package xorm
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -375,7 +374,7 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*core.Column
 		if _, ok := core.SqlTypes[colType]; ok {
 			col.SQLType = core.SQLType{Name: colType, DefaultLength: len1, DefaultLength2: len2}
 		} else {
-			return nil, nil, errors.New(fmt.Sprintf("unkonw colType %v", colType))
+			return nil, nil, fmt.Errorf("Unknown colType %v", colType)
 		}
 
 		if colKey == "PRI" {

--- a/oracle_dialect.go
+++ b/oracle_dialect.go
@@ -5,7 +5,6 @@
 package xorm
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -757,7 +756,7 @@ func (db *oracle) GetColumns(tableName string) ([]string, map[string]*core.Colum
 		}
 
 		if _, ok := core.SqlTypes[col.SQLType.Name]; !ok {
-			return nil, nil, errors.New(fmt.Sprintf("unkonw colType %v %v", *dataType, col.SQLType))
+			return nil, nil, fmt.Errorf("Unknown colType %v %v", *dataType, col.SQLType)
 		}
 
 		col.Length = dataLen

--- a/postgres_dialect.go
+++ b/postgres_dialect.go
@@ -5,7 +5,6 @@
 package xorm
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -990,7 +989,7 @@ WHERE c.relkind = 'r'::char AND c.relname = $1 AND s.table_schema = $2 AND f.att
 			col.SQLType = core.SQLType{Name: strings.ToUpper(dataType), DefaultLength: 0, DefaultLength2: 0}
 		}
 		if _, ok := core.SqlTypes[col.SQLType.Name]; !ok {
-			return nil, nil, errors.New(fmt.Sprintf("unknow colType: %v", dataType))
+			return nil, nil, fmt.Errorf("Unknown colType: %v", dataType)
 		}
 
 		col.Length = maxLen


### PR DESCRIPTION
Fix warnings from `golint` regarding error text formatting:

```
$ golint ./... | grep fmt.Errorf
mssql_dialect.go:383:22: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
mysql_dialect.go:378:21: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
oracle_dialect.go:760:21: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
postgres_dialect.go:993:21: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
```