### PR TITLE
golint: comment on exported (method|type) ... should be of the form ...

### DIFF
--- a/lru_cacher.go
+++ b/lru_cacher.go
@@ -92,7 +92,7 @@ func (m *LRUCacher) GC() {
 	}
 }
 
-// Get all bean's ids according to sql and parameter from cache
+// GetIds returns all bean's ids according to sql and parameter from cache
 func (m *LRUCacher) GetIds(tableName, sql string) interface{} {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -121,7 +121,7 @@ func (m *LRUCacher) GetIds(tableName, sql string) interface{} {
 	return nil
 }
 
-// Get bean according tableName and id from cache
+// GetBean returns bean according tableName and id from cache
 func (m *LRUCacher) GetBean(tableName string, id string) interface{} {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/memory_store.go
+++ b/memory_store.go
@@ -12,7 +12,7 @@ import (
 
 var _ core.CacheStore = NewMemoryStore()
 
-// memory store
+// MemoryStore represents in-memory store
 type MemoryStore struct {
 	store map[interface{}]interface{}
 	mutex sync.RWMutex

--- a/processors.go
+++ b/processors.go
@@ -4,17 +4,17 @@
 
 package xorm
 
-// Executed before an object is initially persisted to the database
+// BeforeInsertProcessor executed before an object is initially persisted to the database
 type BeforeInsertProcessor interface {
 	BeforeInsert()
 }
 
-// Executed before an object is updated
+// BeforeUpdateProcessor executed before an object is updated
 type BeforeUpdateProcessor interface {
 	BeforeUpdate()
 }
 
-// Executed before an object is deleted
+// BeforeDeleteProcessor executed before an object is deleted
 type BeforeDeleteProcessor interface {
 	BeforeDelete()
 }
@@ -34,17 +34,17 @@ type AfterSetProcessor interface {
 //}
 // --
 
-// Executed after an object is persisted to the database
+// AfterInsertProcessor executed after an object is persisted to the database
 type AfterInsertProcessor interface {
 	AfterInsert()
 }
 
-// Executed after an object has been updated
+// AfterUpdateProcessor executed after an object has been updated
 type AfterUpdateProcessor interface {
 	AfterUpdate()
 }
 
-// Executed after an object has been deleted
+// AfterDeleteProcessor executed after an object has been deleted
 type AfterDeleteProcessor interface {
 	AfterDelete()
 }

--- a/session.go
+++ b/session.go
@@ -371,7 +371,7 @@ func (session *Session) DB() *core.DB {
 	return session.db
 }
 
-// Cond return session's conditions
+// Conds returns session query conditions
 func (session *Session) Conds() builder.Cond {
 	return session.Statement.cond
 }

--- a/statement.go
+++ b/statement.go
@@ -128,7 +128,7 @@ func (statement *Statement) Alias(alias string) *Statement {
 	return statement
 }
 
-// Sql add the raw sql statement
+// SQL adds raw sql statement
 func (statement *Statement) SQL(query interface{}, args ...interface{}) *Statement {
 	switch query.(type) {
 	case (*builder.Builder):
@@ -795,14 +795,14 @@ func (statement *Statement) col2NewColsWithQuote(columns ...string) []string {
 	return newColumns
 }
 
-// Generate "Distince col1, col2 " statment
+// Distinct generates "DISTINCT col1, col2 " statement
 func (statement *Statement) Distinct(columns ...string) *Statement {
 	statement.IsDistinct = true
 	statement.Cols(columns...)
 	return statement
 }
 
-// Generate "SELECT ... FOR UPDATE" statment
+// ForUpdate generates "SELECT ... FOR UPDATE" statement
 func (statement *Statement) ForUpdate() *Statement {
 	statement.IsForUpdate = true
 	return statement


### PR DESCRIPTION
Fix warnings from `golint` regarding comments on exported types or methods

```
$ golint ./... | grep 'comment on exported'
lru_cacher.go:95:1: comment on exported method LRUCacher.GetIds should be of the form "GetIds ..."
lru_cacher.go:124:1: comment on exported method LRUCacher.GetBean should be of the form "GetBean ..."
memory_store.go:15:1: comment on exported type MemoryStore should be of the form "MemoryStore ..." (with optional leading article)
processors.go:7:1: comment on exported type BeforeInsertProcessor should be of the form "BeforeInsertProcessor ..." (with optional leading article)
processors.go:12:1: comment on exported type BeforeUpdateProcessor should be of the form "BeforeUpdateProcessor ..." (with optional leading article)
processors.go:17:1: comment on exported type BeforeDeleteProcessor should be of the form "BeforeDeleteProcessor ..." (with optional leading article)
processors.go:37:1: comment on exported type AfterInsertProcessor should be of the form "AfterInsertProcessor ..." (with optional leading article)
processors.go:42:1: comment on exported type AfterUpdateProcessor should be of the form "AfterUpdateProcessor ..." (with optional leading article)
processors.go:47:1: comment on exported type AfterDeleteProcessor should be of the form "AfterDeleteProcessor ..." (with optional leading article)
session.go:374:1: comment on exported method Session.Conds should be of the form "Conds ..."
statement.go:131:1: comment on exported method Statement.SQL should be of the form "SQL ..."
statement.go:798:1: comment on exported method Statement.Distinct should be of the form "Distinct ..."
statement.go:805:1: comment on exported method Statement.ForUpdate should be of the form "ForUpdate ..."
```