### PR TITLE
golint: should omit (type|2nd value) ...

### DIFF
--- a/examples/cachegoroutine.go
+++ b/examples/cachegoroutine.go
@@ -24,7 +24,7 @@ func mysqlEngine() (*xorm.Engine, error) {
 	return xorm.NewEngine("mysql", "root:@/test?charset=utf8")
 }
 
-var u *User = &User{}
+var u = &User{}
 
 func test(engine *xorm.Engine) {
 	err := engine.CreateTables(u)

--- a/examples/conversion.go
+++ b/examples/conversion.go
@@ -15,10 +15,10 @@ type Status struct {
 }
 
 var (
-	Registed Status            = Status{"Registed", "white"}
-	Approved Status            = Status{"Approved", "green"}
-	Removed  Status            = Status{"Removed", "red"}
-	Statuses map[string]Status = map[string]Status{
+	Registed = Status{"Registed", "white"}
+	Approved = Status{"Approved", "green"}
+	Removed  = Status{"Removed", "red"}
+	Statuses = map[string]Status{
 		Registed.Name: Registed,
 		Approved.Name: Approved,
 		Removed.Name:  Removed,

--- a/examples/goroutine.go
+++ b/examples/goroutine.go
@@ -24,7 +24,7 @@ func mysqlEngine() (*xorm.Engine, error) {
 	return xorm.NewEngine("mysql", "root:@/test?charset=utf8")
 }
 
-var u *User = &User{}
+var u = &User{}
 
 func test(engine *xorm.Engine) {
 	err := engine.CreateTables(u)

--- a/examples/maxconnect.go
+++ b/examples/maxconnect.go
@@ -24,7 +24,7 @@ func mysqlEngine() (*xorm.Engine, error) {
 	return xorm.NewEngine("mysql", "root:@/test?charset=utf8")
 }
 
-var u *User = &User{}
+var u = &User{}
 
 func test(engine *xorm.Engine) {
 	err := engine.CreateTables(u)

--- a/mssql_dialect.go
+++ b/mssql_dialect.go
@@ -257,8 +257,9 @@ func (db *mssql) SqlType(c *core.Column) string {
 		return core.Int
 	}
 
-	var hasLen1 bool = (c.Length > 0)
-	var hasLen2 bool = (c.Length2 > 0)
+	hasLen1 := (c.Length > 0)
+	hasLen2 := (c.Length2 > 0)
+
 	if hasLen2 {
 		res += "(" + strconv.Itoa(c.Length) + "," + strconv.Itoa(c.Length2) + ")"
 	} else if hasLen1 {

--- a/mysql_dialect.go
+++ b/mysql_dialect.go
@@ -201,7 +201,7 @@ func (db *mysql) SqlType(c *core.Column) string {
 		res = core.Enum
 		res += "("
 		opts := ""
-		for v, _ := range c.EnumOptions {
+		for v := range c.EnumOptions {
 			opts += fmt.Sprintf(",'%v'", v)
 		}
 		res += strings.TrimLeft(opts, ",")
@@ -210,7 +210,7 @@ func (db *mysql) SqlType(c *core.Column) string {
 		res = core.Set
 		res += "("
 		opts := ""
-		for v, _ := range c.SetOptions {
+		for v := range c.SetOptions {
 			opts += fmt.Sprintf(",'%v'", v)
 		}
 		res += strings.TrimLeft(opts, ",")
@@ -226,8 +226,8 @@ func (db *mysql) SqlType(c *core.Column) string {
 		res = t
 	}
 
-	var hasLen1 bool = (c.Length > 0)
-	var hasLen2 bool = (c.Length2 > 0)
+	hasLen1 := (c.Length > 0)
+	hasLen2 := (c.Length2 > 0)
 
 	if res == core.BigInt && !hasLen1 && !hasLen2 {
 		c.Length = 20

--- a/oracle_dialect.go
+++ b/oracle_dialect.go
@@ -525,8 +525,9 @@ func (db *oracle) SqlType(c *core.Column) string {
 		res = t
 	}
 
-	var hasLen1 bool = (c.Length > 0)
-	var hasLen2 bool = (c.Length2 > 0)
+	hasLen1 := (c.Length > 0)
+	hasLen2 := (c.Length2 > 0)
+
 	if hasLen2 {
 		res += "(" + strconv.Itoa(c.Length) + "," + strconv.Itoa(c.Length2) + ")"
 	} else if hasLen1 {

--- a/postgres_dialect.go
+++ b/postgres_dialect.go
@@ -812,8 +812,9 @@ func (db *postgres) SqlType(c *core.Column) string {
 		res = t
 	}
 
-	var hasLen1 bool = (c.Length > 0)
-	var hasLen2 bool = (c.Length2 > 0)
+	hasLen1 := (c.Length > 0)
+	hasLen2 := (c.Length2 > 0)
+
 	if hasLen2 {
 		res += "(" + strconv.Itoa(c.Length) + "," + strconv.Itoa(c.Length2) + ")"
 	} else if hasLen1 {
@@ -879,9 +880,10 @@ func (db *postgres) ModifyColumnSql(tableName string, col *core.Column) string {
 }
 
 func (db *postgres) DropIndexSql(tableName string, index *core.Index) string {
-	quote := db.Quote
 	//var unique string
-	var idxName string = index.Name
+	quote := db.Quote
+	idxName := index.Name
+
 	if !strings.HasPrefix(idxName, "UQE_") &&
 		!strings.HasPrefix(idxName, "IDX_") {
 		if index.Type == core.UniqueType {

--- a/sqlite3_dialect.go
+++ b/sqlite3_dialect.go
@@ -237,9 +237,10 @@ func (db *sqlite3) TableCheckSql(tableName string) (string, []interface{}) {
 }
 
 func (db *sqlite3) DropIndexSql(tableName string, index *core.Index) string {
-	quote := db.Quote
 	//var unique string
-	var idxName string = index.Name
+	quote := db.Quote
+	idxName := index.Name
+
 	if !strings.HasPrefix(idxName, "UQE_") &&
 		!strings.HasPrefix(idxName, "IDX_") {
 		if index.Type == core.UniqueType {


### PR DESCRIPTION
Fix warnings from `golint` regarding variables declarations

```
golint ./... | grep 'should omit'
mssql_dialect.go:260:14: should omit type bool from declaration of var hasLen1; it will be inferred from the right-hand side
mssql_dialect.go:261:14: should omit type bool from declaration of var hasLen2; it will be inferred from the right-hand side
mysql_dialect.go:204:10: should omit 2nd value from range; this loop is equivalent to `for v := range ...`
mysql_dialect.go:213:10: should omit 2nd value from range; this loop is equivalent to `for v := range ...`
mysql_dialect.go:229:14: should omit type bool from declaration of var hasLen1; it will be inferred from the right-hand side
mysql_dialect.go:230:14: should omit type bool from declaration of var hasLen2; it will be inferred from the right-hand side
oracle_dialect.go:528:14: should omit type bool from declaration of var hasLen1; it will be inferred from the right-hand side
oracle_dialect.go:529:14: should omit type bool from declaration of var hasLen2; it will be inferred from the right-hand side
postgres_dialect.go:815:14: should omit type bool from declaration of var hasLen1; it will be inferred from the right-hand side
postgres_dialect.go:816:14: should omit type bool from declaration of var hasLen2; it will be inferred from the right-hand side
postgres_dialect.go:884:14: should omit type string from declaration of var idxName; it will be inferred from the right-hand side
sqlite3_dialect.go:242:14: should omit type string from declaration of var idxName; it will be inferred from the right-hand side
examples/cachegoroutine.go:27:7: should omit type *User from declaration of var u; it will be inferred from the right-hand side
examples/conversion.go:18:11: should omit type Status from declaration of var Registed; it will be inferred from the right-hand side
examples/conversion.go:19:11: should omit type Status from declaration of var Approved; it will be inferred from the right-hand side
examples/conversion.go:20:11: should omit type Status from declaration of var Removed; it will be inferred from the right-hand side
examples/conversion.go:21:11: should omit type map[string]Status from declaration of var Statuses; it will be inferred from the right-hand side
examples/goroutine.go:27:7: should omit type *User from declaration of var u; it will be inferred from the right-hand side
examples/maxconnect.go:27:7: should omit type *User from declaration of var u; it will be inferred from the right-hand side
```