### PR TITLE
golint: receiver name %s should be consistent with ...

### DIFF
--- a/oracle_dialect.go
+++ b/oracle_dialect.go
@@ -577,14 +577,14 @@ func (db *oracle) DropTableSql(tableName string) string {
 	return fmt.Sprintf("DROP TABLE `%s`", tableName)
 }
 
-func (b *oracle) CreateTableSql(table *core.Table, tableName, storeEngine, charset string) string {
+func (db *oracle) CreateTableSql(table *core.Table, tableName, storeEngine, charset string) string {
 	var sql string
 	sql = "CREATE TABLE "
 	if tableName == "" {
 		tableName = table.Name
 	}
 
-	sql += b.Quote(tableName) + " ("
+	sql += db.Quote(tableName) + " ("
 
 	pkList := table.PrimaryKeys
 
@@ -593,7 +593,7 @@ func (b *oracle) CreateTableSql(table *core.Table, tableName, storeEngine, chars
 		/*if col.IsPrimaryKey && len(pkList) == 1 {
 			sql += col.String(b.dialect)
 		} else {*/
-		sql += col.StringNoPk(b)
+		sql += col.StringNoPk(db)
 		//}
 		sql = strings.TrimSpace(sql)
 		sql += ", "
@@ -601,17 +601,17 @@ func (b *oracle) CreateTableSql(table *core.Table, tableName, storeEngine, chars
 
 	if len(pkList) > 0 {
 		sql += "PRIMARY KEY ( "
-		sql += b.Quote(strings.Join(pkList, b.Quote(",")))
+		sql += db.Quote(strings.Join(pkList, db.Quote(",")))
 		sql += " ), "
 	}
 
 	sql = sql[:len(sql)-2] + ")"
-	if b.SupportEngine() && storeEngine != "" {
+	if db.SupportEngine() && storeEngine != "" {
 		sql += " ENGINE=" + storeEngine
 	}
-	if b.SupportCharset() {
+	if db.SupportCharset() {
 		if len(charset) == 0 {
-			charset = b.URI().Charset
+			charset = db.URI().Charset
 		}
 		if len(charset) > 0 {
 			sql += " DEFAULT CHARSET " + charset

--- a/statement.go
+++ b/statement.go
@@ -809,9 +809,9 @@ func (statement *Statement) ForUpdate() *Statement {
 }
 
 // Select replace select
-func (s *Statement) Select(str string) *Statement {
-	s.selectStr = str
-	return s
+func (statement *Statement) Select(str string) *Statement {
+	statement.selectStr = str
+	return statement
 }
 
 // Cols generate "col1, col2" statement
@@ -1031,11 +1031,11 @@ func (statement *Statement) genCreateTableSQL() string {
 		statement.StoreEngine, statement.Charset)
 }
 
-func (s *Statement) genIndexSQL() []string {
+func (statement *Statement) genIndexSQL() []string {
 	var sqls []string
-	tbName := s.TableName()
-	quote := s.Engine.Quote
-	for idxName, index := range s.RefTable.Indexes {
+	tbName := statement.TableName()
+	quote := statement.Engine.Quote
+	for idxName, index := range statement.RefTable.Indexes {
 		if index.Type == core.IndexType {
 			sql := fmt.Sprintf("CREATE INDEX %v ON %v (%v);", quote(indexName(tbName, idxName)),
 				quote(tbName), quote(strings.Join(index.Cols, quote(","))))
@@ -1049,41 +1049,41 @@ func uniqueName(tableName, uqeName string) string {
 	return fmt.Sprintf("UQE_%v_%v", tableName, uqeName)
 }
 
-func (s *Statement) genUniqueSQL() []string {
+func (statement *Statement) genUniqueSQL() []string {
 	var sqls []string
-	tbName := s.TableName()
-	for _, index := range s.RefTable.Indexes {
+	tbName := statement.TableName()
+	for _, index := range statement.RefTable.Indexes {
 		if index.Type == core.UniqueType {
-			sql := s.Engine.dialect.CreateIndexSql(tbName, index)
+			sql := statement.Engine.dialect.CreateIndexSql(tbName, index)
 			sqls = append(sqls, sql)
 		}
 	}
 	return sqls
 }
 
-func (s *Statement) genDelIndexSQL() []string {
+func (statement *Statement) genDelIndexSQL() []string {
 	var sqls []string
-	tbName := s.TableName()
-	for idxName, index := range s.RefTable.Indexes {
+	tbName := statement.TableName()
+	for idxName, index := range statement.RefTable.Indexes {
 		var rIdxName string
 		if index.Type == core.UniqueType {
 			rIdxName = uniqueName(tbName, idxName)
 		} else if index.Type == core.IndexType {
 			rIdxName = indexName(tbName, idxName)
 		}
-		sql := fmt.Sprintf("DROP INDEX %v", s.Engine.Quote(rIdxName))
-		if s.Engine.dialect.IndexOnTable() {
-			sql += fmt.Sprintf(" ON %v", s.Engine.Quote(s.TableName()))
+		sql := fmt.Sprintf("DROP INDEX %v", statement.Engine.Quote(rIdxName))
+		if statement.Engine.dialect.IndexOnTable() {
+			sql += fmt.Sprintf(" ON %v", statement.Engine.Quote(statement.TableName()))
 		}
 		sqls = append(sqls, sql)
 	}
 	return sqls
 }
 
-func (s *Statement) genAddColumnStr(col *core.Column) (string, []interface{}) {
-	quote := s.Engine.Quote
-	sql := fmt.Sprintf("ALTER TABLE %v ADD %v;", quote(s.TableName()),
-		col.String(s.Engine.dialect))
+func (statement *Statement) genAddColumnStr(col *core.Column) (string, []interface{}) {
+	quote := statement.Engine.Quote
+	sql := fmt.Sprintf("ALTER TABLE %v ADD %v;", quote(statement.TableName()),
+		col.String(statement.Engine.dialect))
 	return sql, []interface{}{}
 }
 


### PR DESCRIPTION
Fix warnings from `golint` regarding receivers name

```
$ golint ./... | grep receiver
oracle_dialect.go:579:1: receiver name b should be consistent with previous receiver name db for oracle
statement.go:812:1: receiver name s should be consistent with previous receiver name statement for Statement
statement.go:1034:1: receiver name s should be consistent with previous receiver name statement for Statement
statement.go:1052:1: receiver name s should be consistent with previous receiver name statement for Statement
statement.go:1064:1: receiver name s should be consistent with previous receiver name statement for Statement
statement.go:1083:1: receiver name s should be consistent with previous receiver name statement for Statement
```