### PR TITLE
Getting flag for the column via helper method

### DIFF
--- a/session.go
+++ b/session.go
@@ -2314,12 +2314,12 @@ func (session *Session) innerInsertMulti(rowsSlicePtr interface{}) (int64, error
 					continue
 				}
 				if session.Statement.ColumnStr != "" {
-					if _, ok := session.Statement.columnMap[strings.ToLower(col.Name)]; !ok {
+					if _, ok := getFlagForColumn(session.Statement.columnMap, col); !ok {
 						continue
 					}
 				}
 				if session.Statement.OmitStr != "" {
-					if _, ok := session.Statement.columnMap[strings.ToLower(col.Name)]; ok {
+					if _, ok := getFlagForColumn(session.Statement.columnMap, col); ok {
 						continue
 					}
 				}
@@ -2369,12 +2369,12 @@ func (session *Session) innerInsertMulti(rowsSlicePtr interface{}) (int64, error
 					continue
 				}
 				if session.Statement.ColumnStr != "" {
-					if _, ok := session.Statement.columnMap[strings.ToLower(col.Name)]; !ok {
+					if _, ok := getFlagForColumn(session.Statement.columnMap, col); !ok {
 						continue
 					}
 				}
 				if session.Statement.OmitStr != "" {
-					if _, ok := session.Statement.columnMap[strings.ToLower(col.Name)]; ok {
+					if _, ok := getFlagForColumn(session.Statement.columnMap, col); ok {
 						continue
 					}
 				}

--- a/statement.go
+++ b/statement.go
@@ -273,9 +273,8 @@ func buildUpdates(engine *Engine, table *core.Table, bean interface{},
 
 		requiredField := useAllCols
 		includeNil := useAllCols
-		lColName := strings.ToLower(col.Name)
 
-		if b, ok := mustColumnMap[lColName]; ok {
+		if b, ok := getFlagForColumn(mustColumnMap, col); ok {
 			if b {
 				requiredField = true
 			} else {
@@ -284,7 +283,7 @@ func buildUpdates(engine *Engine, table *core.Table, bean interface{},
 		}
 
 		// !evalphobia! set fieldValue as nil when column is nullable and zero-value
-		if b, ok := nullableMap[lColName]; ok {
+		if b, ok := getFlagForColumn(nullableMap, col); ok {
 			if b && col.Nullable && isZero(fieldValue.Interface()) {
 				var nilValue *int
 				fieldValue = reflect.ValueOf(nilValue)
@@ -533,7 +532,8 @@ func buildConds(engine *Engine, table *core.Table, bean interface{},
 
 		fieldType := reflect.TypeOf(fieldValue.Interface())
 		requiredField := useAllCols
-		if b, ok := mustColumnMap[strings.ToLower(col.Name)]; ok {
+
+		if b, ok := getFlagForColumn(mustColumnMap, col); ok {
 			if b {
 				requiredField = true
 			} else {
@@ -993,7 +993,7 @@ func (statement *Statement) genColumnStr() string {
 	for _, col := range columns {
 
 		if statement.OmitStr != "" {
-			if _, ok := statement.columnMap[strings.ToLower(col.Name)]; ok {
+			if _, ok := getFlagForColumn(statement.columnMap, col); ok {
 				continue
 			}
 		}

--- a/statement_test.go
+++ b/statement_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/go-xorm/core"
 )
 
@@ -79,6 +81,70 @@ func BenchmarkColumnsStringGeneration(b *testing.B) {
 
 		if actual != testCase.expected {
 			b.Errorf("Unexpected columns string:\nwant:\t%s\nhave:\t%s", testCase.expected, actual)
+		}
+	}
+}
+
+func BenchmarkGetFlagForColumnWithICKey_ContainsKey(b *testing.B) {
+
+	b.StopTimer()
+
+	mapCols := make(map[string]bool)
+	cols := []*core.Column{
+		&core.Column{Name: `ID`},
+		&core.Column{Name: `IsDeleted`},
+		&core.Column{Name: `Caption`},
+		&core.Column{Name: `Code1`},
+		&core.Column{Name: `Code2`},
+		&core.Column{Name: `Code3`},
+		&core.Column{Name: `ParentID`},
+		&core.Column{Name: `Latitude`},
+		&core.Column{Name: `Longitude`},
+	}
+
+	for _, col := range cols {
+		mapCols[strings.ToLower(col.Name)] = true
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+
+		for _, col := range cols {
+
+			if _, ok := getFlagForColumn(mapCols, col); !ok {
+				b.Fatal("Unexpected result")
+			}
+		}
+	}
+}
+
+func BenchmarkGetFlagForColumnWithICKey_EmptyMap(b *testing.B) {
+
+	b.StopTimer()
+
+	mapCols := make(map[string]bool)
+	cols := []*core.Column{
+		&core.Column{Name: `ID`},
+		&core.Column{Name: `IsDeleted`},
+		&core.Column{Name: `Caption`},
+		&core.Column{Name: `Code1`},
+		&core.Column{Name: `Code2`},
+		&core.Column{Name: `Code3`},
+		&core.Column{Name: `ParentID`},
+		&core.Column{Name: `Latitude`},
+		&core.Column{Name: `Longitude`},
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+
+		for _, col := range cols {
+
+			if _, ok := getFlagForColumn(mapCols, col); ok {
+				b.Fatal("Unexpected result")
+			}
 		}
 	}
 }


### PR DESCRIPTION
Columns in the maps (such as `statement.columnMap`, `statement.mustColumnMap`, `statement.nullableMap`) are placed in lowercase.

Each time, when there is need to get any flag from map, name of the column converts to lowercase. Every calling of `strings.ToLower` makes new allocations.

As an example -  all columns in function `statement.buildConds`are checking via `statement.mustColumnMap` (which is filled up only for update statements). This operation makes 2*columns_count unnecessary allocations.

Simple way to fix it - is to make helper method for flag getting from the map via case insensitive keys comparison.

Benchmarks of the current realization and offered way above (simple flag getting from the map, 9 columns):
```
BenchmarkGetFlagForColumnWithToLower_ContainsKey-4   	 1000000	      1911 ns/op	     144 B/op	      18 allocs/op
BenchmarkGetFlagForColumnWithToLower_EmptyMap-4      	 1000000	      1661 ns/op	     144 B/op	      18 allocs/op

BenchmarkGetFlagForColumnWithICKey_ContainsKey-4     	 1000000	      1935 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetFlagForColumnWithICKey_EmptyMap-4        	50000000	        40.8 ns/op	       0 B/op	       0 allocs/op
```