### PR TITLE
Using varchar(max) instead of text in mssql

### DIFF
--- a/mssql_dialect.go
+++ b/mssql_dialect.go
@@ -242,8 +242,8 @@ func (db *mssql) SqlType(c *core.Column) string {
 		c.Length = 7
 	case core.MediumInt:
 		res = core.Int
-	case core.MediumText, core.TinyText, core.LongText, core.Json:
-		res = core.Text
+	case core.Text, core.MediumText, core.TinyText, core.LongText, core.Json:
+		res = core.Varchar + "(MAX)"
 	case core.Double:
 		res = core.Real
 	case core.Uuid:


### PR DESCRIPTION
According to [https://msdn.microsoft.com/en-us/library/ms187993.aspx](https://msdn.microsoft.com/en-us/library/ms187993.aspx) the column type text should not be used any more in mssql. Furthermore the type text is causing problems as one can see in this pull request to gogs: [#3772](https://github.com/gogits/gogs/pull/3772).

To circumvent this problems text should be mapped to varchar(max) as proposed in the link to the msdn above.