### PR TITLE
For nullable columns, store nil values as NULL

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -147,6 +147,17 @@ func isZero(k interface{}) bool {
 	return false
 }
 
+func isZeroValue(v reflect.Value) bool {
+	if isZero(v.Interface()) {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
+}
+
 func isStructZero(v reflect.Value) bool {
 	if !v.IsValid() {
 		return true
@@ -539,7 +550,7 @@ func genCols(table *core.Table, session *Session, bean interface{}, useCol bool,
 
 		// !evalphobia! set fieldValue as nil when column is nullable and zero-value
 		if _, ok := getFlagForColumn(session.Statement.nullableMap, col); ok {
-			if col.Nullable && isZero(fieldValue.Interface()) {
+			if col.Nullable && isZeroValue(fieldValue) {
 				var nilValue *int
 				fieldValue = reflect.ValueOf(nilValue)
 			}


### PR DESCRIPTION
I have a struct defined as:
```
type foo struct {
  field *MyStruct `xorm:"text null"`
}
```

If `field` is nil, I would like `NULL` stored in the database. Currently, however, it stores the string "null".  I think this is an error since the zero value of `*MyStruct` is nil.

This PR fixes this by using reflect.IsNil to determine whether a field's value is nil for the types where it makes sense.