### PR TITLE
update for valueof interface

### DIFF
--- a/session_insert.go
+++ b/session_insert.go
@@ -67,7 +67,7 @@ func (session *Session) innerInsertMulti(rowsSlicePtr interface{}) (int64, error
 		return 0, errors.New("could not insert a empty slice")
 	}
 
-	if err := session.Statement.setRefValue(sliceValue.Index(0)); err != nil {
+	if err := session.Statement.setRefValue(reflect.ValueOf(sliceValue.Index(0).Interface())); err != nil {
 		return 0, err
 	}
 

--- a/session_insert_test.go
+++ b/session_insert_test.go
@@ -5,6 +5,8 @@
 package xorm
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -25,4 +27,80 @@ func TestInsertOne(t *testing.T) {
 	data := Test{Msg: "hi"}
 	_, err := testEngine.InsertOne(data)
 	assert.NoError(t, err)
+}
+
+func TestInsertMulti(t *testing.T) {
+
+	assert.NoError(t, prepareEngine())
+	type TestMulti struct {
+		Id   int64  `xorm:"int(11) pk"`
+		Name string `xorm:"varchar(255)"`
+	}
+
+	assert.NoError(t, testEngine.Sync2(new(TestMulti)))
+
+	num, err := insertMultiDatas(1,
+		append([]TestMulti{}, TestMulti{1, "test1"}, TestMulti{2, "test2"}, TestMulti{3, "test3"}))
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, num)
+}
+
+func insertMultiDatas(step int, datas interface{}) (num int64, err error) {
+	sliceValue := reflect.Indirect(reflect.ValueOf(datas))
+	var iLen int64
+	if sliceValue.Kind() != reflect.Slice {
+		return 0, fmt.Errorf("not silce")
+	}
+	iLen = int64(sliceValue.Len())
+	if iLen == 0 {
+		return
+	}
+
+	session := testEngine.NewSession()
+	defer session.Close()
+
+	if err = callbackLooper(datas, step,
+		func(innerDatas interface{}) error {
+			n, e := session.InsertMulti(innerDatas)
+			if e != nil {
+				return e
+			}
+			num += n
+			return nil
+		}); err != nil {
+		return 0, err
+	} else if num != iLen {
+		return 0, fmt.Errorf("num error: %d - %d", num, iLen)
+	}
+	return
+}
+
+func callbackLooper(datas interface{}, step int, actionFunc func(interface{}) error) (err error) {
+
+	sliceValue := reflect.Indirect(reflect.ValueOf(datas))
+	if sliceValue.Kind() != reflect.Slice {
+		return fmt.Errorf("not slice")
+	}
+	if sliceValue.Len() <= 0 {
+		return
+	}
+
+	tempLen := 0
+	processedLen := sliceValue.Len()
+	for i := 0; i < sliceValue.Len(); i += step {
+		if processedLen > step {
+			tempLen = i + step
+		} else {
+			tempLen = sliceValue.Len()
+		}
+		var tempInterface []interface{}
+		for j := i; j < tempLen; j++ {
+			tempInterface = append(tempInterface, sliceValue.Index(j).Interface())
+		}
+		if err = actionFunc(tempInterface); err != nil {
+			return
+		}
+		processedLen = processedLen - step
+	}
+	return
 }


### PR DESCRIPTION
是因为如果slice的数据比较大，超出了sql的执行字符长度。那我将slice做了切分，并按认为可执行的长度[]interface{}传入到insertMulti中，xorm version: 769f6b3ae663248e8f1b1d8fecbe1eb26ac77ac7 是支持的。到了现在的版本不支持，加上reflect.ValueOf(Value.Interface())即可，本人已测过