### PR TITLE
fix bugs cols with incr when update

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -400,6 +400,10 @@ func genCols(table *core.Table, session *Session, bean interface{}, useCol bool,
 		if session.Statement.ColumnStr != "" {
 			if _, ok := getFlagForColumn(session.Statement.columnMap, col); !ok {
 				continue
+			} else if _, ok := session.Statement.incrColumns[col.Name]; ok {
+				continue
+			} else if _, ok := session.Statement.decrColumns[col.Name]; ok {
+				continue
 			}
 		}
 		if session.Statement.OmitStr != "" {


### PR DESCRIPTION
When use `Cols` with `Incr` or `Decr`, it will generate two update sets. This PR will fix that. When `Cols` with `Incr` or `Decr`. The same column on `Cols` will be ignored.