### PR TITLE
modify cache_test for issues #330

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -15,7 +15,7 @@ func TestCacheFind(t *testing.T) {
 	assert.NoError(t, prepareEngine())
 
 	type MailBox struct {
-		Id       int64
+		Id       int64 `xorm:"pk"`
 		Username string
 		Password string
 	}
@@ -27,10 +27,12 @@ func TestCacheFind(t *testing.T) {
 
 	var inserts = []*MailBox{
 		{
+			Id:       0,
 			Username: "user1",
 			Password: "pass1",
 		},
 		{
+			Id:       1,
 			Username: "user2",
 			Password: "pass2",
 		},
@@ -63,7 +65,7 @@ func TestCacheFind2(t *testing.T) {
 	assert.NoError(t, prepareEngine())
 
 	type MailBox2 struct {
-		Id       uint64
+		Id       uint64 `xorm:"pk"`
 		Username string
 		Password string
 	}
@@ -75,10 +77,12 @@ func TestCacheFind2(t *testing.T) {
 
 	var inserts = []*MailBox2{
 		{
+			Id:       0,
 			Username: "user1",
 			Password: "pass1",
 		},
 		{
+			Id:       1,
 			Username: "user2",
 			Password: "pass2",
 		},


### PR DESCRIPTION
PK should be defined for hitting cache.
In this test, only the function "TestCacheFind2" will return wrong error.
https://github.com/go-xorm/xorm/commit/5b65f21ae40536004d83f5992466af31011acadc

```
[xorm] [info]  2017/07/05 00:14:32.340455 [SQL] SELECT `id`, `username`, `password` FROM `mail_box2` WHERE `id` IN (?,?) [0 1]
[xorm] [debug] 2017/07/05 00:14:32.340568 [cacheFind] cache bean:mail_box2[0] &{0 user1 pass1} [0xc42001bd10 <nil>]
[xorm] [debug] 2017/07/05 00:14:32.340579 [cacheFind] cache bean:mail_box2[1] &{1 user2 pass2} [0xc42001bd38 <nil>]
[xorm] [warn]  2017/07/05 00:14:32.340583 [cacheFind] cache no hit:mail_box2[1] [0xc42001bd38 <nil>]
--- FAIL: TestCacheFind2 (0.00s)
        Error Trace:    cache_test.go:95
        Error:          Not equal: 2 (expected)
                                != 1 (actual)

        Error Trace:    cache_test.go:97
        Error:          Not equal: 0x0 (expected)
                                != 0x1 (actual)

        Error Trace:    cache_test.go:98
        Error:          Not equal: "user1" (expected)
                                != "user2" (actual)

        Error Trace:    cache_test.go:99
        Error:          Not equal: "pass1" (expected)
                                != "pass2" (actual)

        Error Trace:    cache_test.go:104
        Error:          Not equal: 2 (expected)
                                != 1 (actual)

        Error Trace:    cache_test.go:106
        Error:          Not equal: 0x0 (expected)
                                != 0x1 (actual)

        Error Trace:    cache_test.go:107
        Error:          Not equal: "user1" (expected)
                                != "user2" (actual)

        Error Trace:    cache_test.go:108
        Error:          Not equal: "pass1" (expected)
                                != "pass2" (actual)

FAIL
exit status 1
FAIL    github.com/mamoroom/xorm        0.091s
```