### PR TITLE
add string support

### DIFF
--- a/session.go
+++ b/session.go
@@ -425,6 +425,10 @@ func (session *Session) slice2Bean(scanResults []interface{}, fields []string, f
 				hasAssigned = true
 
 				if len(bs) > 0 {
+					if fieldType.Kind() == reflect.String {
+						fieldValue.SetString(string(bs))
+						continue
+					}
 					if fieldValue.CanAddr() {
 						err := json.Unmarshal(bs, fieldValue.Addr().Interface())
 						if err != nil {


### PR DESCRIPTION
数据库中的 json 理应被 golang 端的 string 类型支持，以前使用 xorm 生成的对象就是 json 映射到 golang string 类型的。