### PR TITLE
improve processors

### DIFF
--- a/processors.go
+++ b/processors.go
@@ -29,13 +29,6 @@ type AfterSetProcessor interface {
 	AfterSet(string, Cell)
 }
 
-// !nashtsai! TODO enable BeforeValidateProcessor when xorm start to support validations
-//// Executed before an object is validated
-//type BeforeValidateProcessor interface {
-//    BeforeValidate()
-//}
-// --
-
 // AfterInsertProcessor executed after an object is persisted to the database
 type AfterInsertProcessor interface {
 	AfterInsert()
@@ -49,4 +42,37 @@ type AfterUpdateProcessor interface {
 // AfterDeleteProcessor executed after an object has been deleted
 type AfterDeleteProcessor interface {
 	AfterDelete()
+}
+
+// AfterLoadProcessor executed after an ojbect has been loaded from database
+type AfterLoadProcessor interface {
+	AfterLoad()
+}
+
+// AfterLoadSessionProcessor executed after an ojbect has been loaded from database with session parameter
+type AfterLoadSessionProcessor interface {
+	AfterLoad(*Session)
+}
+
+type executedProcessorFunc func(*Session, interface{}) error
+
+type executedProcessor struct {
+	fun     executedProcessorFunc
+	session *Session
+	bean    interface{}
+}
+
+func (executor *executedProcessor) execute() error {
+	return executor.fun(executor.session, executor.bean)
+}
+
+func (session *Session) executeProcessors() error {
+	processors := session.afterProcessors
+	session.afterProcessors = make([]executedProcessor, 0)
+	for _, processor := range processors {
+		if err := processor.execute(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/rows.go
+++ b/rows.go
@@ -99,13 +99,17 @@ func (rows *Rows) Scan(bean interface{}) error {
 		return err
 	}
 
-	scanResults, err := rows.session.row2Slice(rows.rows, rows.fields, len(rows.fields), bean)
+	scanResults, err := rows.session.row2Slice(rows.rows, rows.fields, bean)
 	if err != nil {
 		return err
 	}
 
-	_, err = rows.session.slice2Bean(scanResults, rows.fields, len(rows.fields), bean, &dataStruct, rows.session.statement.RefTable)
-	return err
+	_, err = rows.session.slice2Bean(scanResults, rows.fields, bean, &dataStruct, rows.session.statement.RefTable)
+	if err != nil {
+		return err
+	}
+
+	return rows.session.executeProcessors()
 }
 
 // Close session if session.IsAutoClose is true, and claimed any opened resources

--- a/session_find.go
+++ b/session_find.go
@@ -239,7 +239,12 @@ func (session *Session) noCacheFind(table *core.Table, containerValue reflect.Va
 		if err != nil {
 			return err
 		}
-		return session.rows2Beans(rows, fields, len(fields), tb, newElemFunc, containerValueSetFunc)
+		err = session.rows2Beans(rows, fields, tb, newElemFunc, containerValueSetFunc)
+		rows.Close()
+		if err != nil {
+			return err
+		}
+		return session.executeProcessors()
 	}
 
 	for rows.Next() {

--- a/session_get.go
+++ b/session_get.go
@@ -87,7 +87,7 @@ func (session *Session) nocacheGet(beanKind reflect.Kind, table *core.Table, bea
 			return true, err
 		}
 
-		scanResults, err := session.row2Slice(rows, fields, len(fields), bean)
+		scanResults, err := session.row2Slice(rows, fields, bean)
 		if err != nil {
 			return false, err
 		}
@@ -95,7 +95,12 @@ func (session *Session) nocacheGet(beanKind reflect.Kind, table *core.Table, bea
 		rows.Close()
 
 		dataStruct := rValue(bean)
-		_, err = session.slice2Bean(scanResults, fields, len(fields), bean, &dataStruct, table)
+		_, err = session.slice2Bean(scanResults, fields, bean, &dataStruct, table)
+		if err != nil {
+			return true, err
+		}
+
+		return true, session.executeProcessors()
 	case reflect.Slice:
 		err = rows.ScanSlice(bean)
 	case reflect.Map:


### PR DESCRIPTION
This PR adds a new processor `AfterLoad`, it will be called after an object loaded from database and rows closed (except when you call `Rows`). That means we can reuse the session on `AfterLoad` like https://github.com/go-xorm/xorm/pull/743/files#diff-743fb9433abb258bf1fd1d441499f749R982 .