### PR TITLE
mysql8.0 中同步数据前，获取数据库结构，因tableRaw为空导致同步失败

### DIFF
--- a/mysql_dialect.go
+++ b/mysql_dialect.go
@@ -413,7 +413,7 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*core.Column
 
 func (db *mysql) GetTables() ([]*core.Table, error) {
 	args := []interface{}{db.DbName}
-	s := "SELECT `TABLE_NAME`, `ENGINE`, `TABLE_ROWS`, `AUTO_INCREMENT` from " +
+	s := "SELECT `TABLE_NAME`, `ENGINE`, `AUTO_INCREMENT` from " +
 		"`INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_SCHEMA`=? AND (`ENGINE`='MyISAM' OR `ENGINE` = 'InnoDB')"
 
 	rows, err := db.DB().Query(s, args...)
@@ -428,9 +428,9 @@ func (db *mysql) GetTables() ([]*core.Table, error) {
 	tables := make([]*core.Table, 0)
 	for rows.Next() {
 		table := core.NewEmptyTable()
-		var name, engine, tableRows string
+		var name, engine string
 		var autoIncr *string
-		err = rows.Scan(&name, &engine, &tableRows, &autoIncr)
+		err = rows.Scan(&name, &engine, &autoIncr)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1935979/34034073-f6ac2fb4-e1b7-11e7-82d6-4dfb712d406e.png)

tableRaws为空是，会提示
Scan error on column index 2: unsupported Scan, storing driver.Value type <nil> into type *string
