### PR TITLE
Convert args to database time

### DIFF
--- a/session_raw.go
+++ b/session_raw.go
@@ -21,9 +21,28 @@ func (session *Session) queryPreprocess(sqlStr *string, paramStr ...interface{})
 	session.lastSQLArgs = paramStr
 }
 
+func (session *Session) argsConverter(args ...interface{}) []interface{} {
+	if session.engine.DatabaseTZ == nil {
+		return args
+	}
+	for i, arg := range args {
+		switch t := arg.(type) {
+		case time.Time:
+			args[i] = t.In(session.engine.DatabaseTZ)
+		case *time.Time:
+			if t != nil {
+				dbTime := t.In(session.engine.DatabaseTZ)
+				args[i] = &dbTime
+			}
+		}
+	}
+	return args
+}
+
 func (session *Session) queryRows(sqlStr string, args ...interface{}) (*core.Rows, error) {
 	defer session.resetStatement()
 
+	args = session.argsConverter(args)
 	session.queryPreprocess(&sqlStr, args...)
 
 	if session.engine.showSQL {
@@ -150,7 +169,7 @@ func (session *Session) queryBytes(sqlStr string, args ...interface{}) ([]map[st
 
 func (session *Session) exec(sqlStr string, args ...interface{}) (sql.Result, error) {
 	defer session.resetStatement()
-
+	args = session.argsConverter(args)
 	session.queryPreprocess(&sqlStr, args...)
 
 	if session.engine.showSQL {


### PR DESCRIPTION
I found that the args parameter are not convert to the timezone of `sesssion.engine.DatabaseTZ` 

this will cause a problem that the time write into database may be not correct 