### PR TITLE
replace retval of ToDB with `{}interface(nil)`

### DIFF
--- a/session_convert.go
+++ b/session_convert.go
@@ -541,6 +541,9 @@ func (session *Session) value2Interface(col *core.Column, fieldValue reflect.Val
 				return 0, err
 			}
 			if col.SQLType.IsBlob() {
+				if data == nil {
+					return nil, nil
+				}
 				return data, nil
 			}
 			return string(data), nil
@@ -553,6 +556,9 @@ func (session *Session) value2Interface(col *core.Column, fieldValue reflect.Val
 			return 0, err
 		}
 		if col.SQLType.IsBlob() {
+			if data == nil {
+				return nil, nil
+			}
 			return data, nil
 		}
 		return string(data), nil

--- a/statement.go
+++ b/statement.go
@@ -305,7 +305,9 @@ func (statement *Statement) buildUpdates(bean interface{},
 				if err != nil {
 					engine.logger.Error(err)
 				} else {
-					val = data
+					if data != nil {
+						val = data
+					}
 				}
 				goto APPEND
 			}
@@ -316,7 +318,9 @@ func (statement *Statement) buildUpdates(bean interface{},
 			if err != nil {
 				engine.logger.Error(err)
 			} else {
-				val = data
+				if data != nil {
+					val = data
+				}
 			}
 			goto APPEND
 		}


### PR DESCRIPTION
instead of `[]byte(nil)`.

current custom types can't be set to `NULL`.
because some drivers ([like lib/pq](https://github.com/lib/pq/issues/773)) don't consider that `[]byte(nil)` is NULL . when `ToDB()` return `nil`, it is `[]byte(nil)`.

This PR checks return values from `ToDB()`, and when it is `[]byte(nil)`
translates those to `{}interface(nil)`