### PR TITLE
fix #1075 使用EngineGroup实现一主多从集群，无法从Master执行Sql查询，并且总是从Slave查询。

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -308,6 +308,13 @@ func (engine *Engine) NewSession() *Session {
 	return session
 }
 
+func (engine *Engine) NewMasterSession() *Session {
+	session := &Session{engine: engine}
+	session.Init()
+	session.isMasterOwn=true
+	return session
+}
+
 // Close the engine
 func (engine *Engine) Close() error {
 	return engine.db.Close()

--- a/session.go
+++ b/session.go
@@ -27,6 +27,7 @@ type Session struct {
 	isAutoCommit           bool
 	isCommitedOrRollbacked bool
 	isAutoClose            bool
+	isMasterOwn		       bool
 
 	// Automatically reset the statement after operations that execute a SQL
 	// query such as Count(), Find(), Get(), ...
@@ -69,6 +70,7 @@ func (session *Session) Init() {
 	session.isAutoClose = false
 	session.autoResetStatement = true
 	session.prepareStmt = false
+	session.isMasterOwn = false
 
 	// !nashtsai! is lazy init better?
 	session.afterInsertBeans = make(map[interface{}]*[]func(interface{}), 0)

--- a/session_raw.go
+++ b/session_raw.go
@@ -49,11 +49,17 @@ func (session *Session) queryRows(sqlStr string, args ...interface{}) (*core.Row
 
 	if session.isAutoCommit {
 		var db *core.DB
-		if session.engine.engineGroup != nil {
-			db = session.engine.engineGroup.Slave().DB()
-		} else {
+
+		if session.isMasterOwn{
 			db = session.DB()
+		}else{
+			if session.engine.engineGroup != nil {
+				db = session.engine.engineGroup.Slave().DB()
+			} else {
+				db = session.DB()
+			}
 		}
+
 
 		if session.prepareStmt {
 			// don't clear stmt since session will cache them


### PR DESCRIPTION
fix #1075 使用EngineGroup实现一主多从集群，无法从Master执行Sql查询，并且总是从Slave查询。