### PR TITLE
Propagate errors from SQL row reading

### DIFF
--- a/session_get.go
+++ b/session_get.go
@@ -77,6 +77,9 @@ func (session *Session) nocacheGet(beanKind reflect.Kind, table *core.Table, bea
 	defer rows.Close()
 
 	if !rows.Next() {
+		if rows.Err() != nil {
+			return false, rows.Err()
+		}
 		return false, nil
 	}
 


### PR DESCRIPTION
Currently errors while data is being read are being swallowed and result in a truncated result set, this fixes that and properly returns an error and not an incomplete result.