### PR TITLE
fix: when time is zero, let it use db default value if possible

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1547,7 +1547,7 @@ func (engine *Engine) nowTime(col *core.Column) (interface{}, time.Time) {
 
 func (engine *Engine) formatColTime(col *core.Column, t time.Time) (v interface{}) {
 	if t.IsZero() {
-		if col.Nullable {
+		if col.Nullable || !col.DefaultIsEmpty {
 			return nil
 		}
 		return ""


### PR DESCRIPTION
fix: for time.Time field, when time is zero and db field has default value, then return nil to use db default value