### PR TITLE
check driver.Valuer response, and skip the column if nil

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -384,6 +384,9 @@ func (statement *Statement) buildUpdates(bean interface{},
 				val = engine.formatColTime(col, t)
 			} else if nulType, ok := fieldValue.Interface().(driver.Valuer); ok {
 				val, _ = nulType.Value()
+				if val == nil && !requiredField {
+					continue
+				}
 			} else {
 				if !col.SQLType.IsJson() {
 					engine.autoMapType(fieldValue)


### PR DESCRIPTION
**Problem:**
Some sort of column are updated by nil always, when type for the column implements `driver.Valuer` interface and it's `Value()` method return `nil`. It should be check `requiredField`.

**Solution:**
Check the response value of `driver.Valuer.Value()`, if it is `nil` and not `requiredField`, skip the column.