### PR TITLE
增加Cols()方法使用别名的功能

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -636,6 +636,9 @@ func (statement *Statement) Cols(columns ...string) *Statement {
 
 	statement.ColumnStr = strings.Join(newColumns, ", ")
 	statement.ColumnStr = strings.Replace(statement.ColumnStr, statement.Engine.quote("*"), "*", -1)
+	var quoteStr = statement.Engine.dialect.QuoteStr()
+	statement.ColumnStr = strings.Replace(statement.ColumnStr, " AS ", quoteStr+" AS "+quoteStr, -1)
+	statement.ColumnStr = strings.Replace(statement.ColumnStr, " as ", quoteStr+" AS "+quoteStr, -1)
 	return statement
 }
 


### PR DESCRIPTION
我在项目中需要给查询的字段重命名，代码如下：
`
u:=new(User)	
sx := this.Session().Table('users').Cols( "username as nick").Get(&u)
`
通过xorm生成的sql语句如下：
`
select `username as age` from users
`
执行报错：
Unknown column 'users.username as nick' in 'field list'
修改后别名功能可正常使用
使用方法：
`
engine.Cols( "username as nick")
engine.Cols( "username AS nick")
`