### PR TITLE
Fix mssql issue with duplicate columns.

### DIFF
--- a/dialect_mssql.go
+++ b/dialect_mssql.go
@@ -340,14 +340,15 @@ func (db *mssql) GetColumns(tableName string) ([]string, map[string]*core.Column
 	args := []interface{}{}
 	s := `select a.name as name, b.name as ctype,a.max_length,a.precision,a.scale,a.is_nullable as nullable,
 	      replace(replace(isnull(c.text,''),'(',''),')','') as vdefault,
-		  ISNULL(i.is_primary_key, 0)
+		  ISNULL(p.is_primary_key, 0)
           from sys.columns a 
 		  left join sys.types b on a.user_type_id=b.user_type_id
           left join sys.syscomments c on a.default_object_id=c.id
-		  LEFT OUTER JOIN 
-    sys.index_columns ic ON ic.object_id = a.object_id AND ic.column_id = a.column_id
-		  LEFT OUTER JOIN 
-    sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+		  LEFT OUTER JOIN (SELECT i.object_id, ic.column_id, i.is_primary_key
+		    FROM sys.indexes i
+		     LEFT JOIN sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+		    WHERE i.is_primary_key = 1
+		  ) as p on p.object_id = a.object_id AND p.column_id = a.column_id
           where a.object_id=object_id('` + tableName + `')`
 	db.LogSQL(s, args)
 


### PR DESCRIPTION
The `GetColumns()` method for the mssql dialect can return the same
column multiple times if the column is in multiple indexes.