### PR TITLE
fix bug in oracle： engine.Table(tablename).Exist()

### DIFF
--- a/session_exist.go
+++ b/session_exist.go
@@ -42,6 +42,8 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 
 				if session.engine.dialect.DBType() == core.MSSQL {
 					sqlStr = fmt.Sprintf("SELECT TOP 1 * FROM %s WHERE %s", tableName, condSQL)
+				} else if session.engine.dialect.DBType() == core.ORACLE {
+					sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE (%s) AND ROWNUM=1", tableName, condSQL)
 				} else {
 					sqlStr = fmt.Sprintf("SELECT * FROM %s WHERE %s LIMIT 1", tableName, condSQL)
 				}
@@ -49,6 +51,8 @@ func (session *Session) Exist(bean ...interface{}) (bool, error) {
 			} else {
 				if session.engine.dialect.DBType() == core.MSSQL {
 					sqlStr = fmt.Sprintf("SELECT TOP 1 * FROM %s", tableName)
+				} else if session.engine.dialect.DBType() == core.ORACLE {
+					sqlStr = fmt.Sprintf("SELECT * FROM  %s WHERE ROWNUM=1", tableName)
 				} else {
 					sqlStr = fmt.Sprintf("SELECT * FROM %s LIMIT 1", tableName)
 				}


### PR DESCRIPTION
oracle中没有 limit 关键字， 使用 rownum