### PR TITLE
去除 version 字段的 Add 条件

### DIFF
--- a/session_update.go
+++ b/session_update.go
@@ -280,7 +280,7 @@ func (session *Session) Update(bean interface{}, condiBean ...interface{}) (int6
 			return 0, err
 		}
 
-		cond = cond.And(builder.Eq{session.engine.Quote(table.Version): verValue.Interface()})
+		// cond = cond.And(builder.Eq{session.engine.Quote(table.Version): verValue.Interface()})
 		colNames = append(colNames, session.engine.Quote(table.Version)+" = "+session.engine.Quote(table.Version)+" + 1")
 	}
 


### PR DESCRIPTION
当 结构体开启 version tag 时, 使用 update 方法, 第一个参数(更新的字段)结构体指针中 Version 字段默认为 0, 导致找不到更新的数据.
调用的方式为:
```
update := &FeedItem{
	DatePublished: "2019-01-9",
}
engine.Where("date_published = ?", "2019-01-11").Update(update)
```
生成的 sql 类似于:
```
[xorm] [info]  2019/02/14 17:36:46.057228 [SQL] UPDATE "feed_item" SET "date_published" = $1, "updated" = $2, "version" = "version" + 1 WHERE (date_published = $3) AND "version"=$4 []interface {}{"2019-01-9", 1550137006, "2019-01-11", 0}
```