### PR TITLE
Allow adding prefix for fields with `extends` tag

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -922,7 +922,16 @@ func (engine *Engine) mapType(v reflect.Value) (*core.Table, error) {
 					engine:     engine,
 				}
 
-				if strings.ToUpper(tags[0]) == "EXTENDS" {
+				if strings.HasPrefix(strings.ToUpper(tags[0]), "EXTENDS") {
+					pStart := strings.Index(tags[0], "(")
+					if pStart > -1 && strings.HasSuffix(tags[0], ")") {
+						var tagPrefix = strings.TrimFunc(tags[0][pStart+1:len(tags[0])-1], func(r rune) bool {
+							return r == '\'' || r == '"'
+						})
+
+						ctx.params = []string{tagPrefix}
+					}
+
 					if err := ExtendsTagHandler(&ctx); err != nil {
 						return nil, err
 					}

--- a/tag.go
+++ b/tag.go
@@ -244,6 +244,7 @@ func SQLTypeTagHandler(ctx *tagContext) error {
 // ExtendsTagHandler describes extends tag handler
 func ExtendsTagHandler(ctx *tagContext) error {
 	var fieldValue = ctx.fieldValue
+	var isPtr = false
 	switch fieldValue.Kind() {
 	case reflect.Ptr:
 		f := fieldValue.Type().Elem()
@@ -254,6 +255,7 @@ func ExtendsTagHandler(ctx *tagContext) error {
 				fieldValue = reflect.New(f).Elem()
 			}
 		}
+		isPtr = true
 		fallthrough
 	case reflect.Struct:
 		parentTable, err := ctx.engine.mapType(fieldValue)
@@ -262,6 +264,24 @@ func ExtendsTagHandler(ctx *tagContext) error {
 		}
 		for _, col := range parentTable.Columns() {
 			col.FieldName = fmt.Sprintf("%v.%v", ctx.col.FieldName, col.FieldName)
+
+			var tagPrefix = ctx.col.FieldName
+			if len(ctx.params) > 0 {
+				col.Nullable = isPtr
+				tagPrefix = ctx.params[0]
+				if col.IsPrimaryKey {
+					col.Name = ctx.col.FieldName
+					col.IsPrimaryKey = false
+				} else {
+					col.Name = fmt.Sprintf("%v%v", tagPrefix, col.Name)
+				}
+			}
+
+			if col.Nullable {
+				col.IsAutoIncrement = false
+				col.IsPrimaryKey = false
+			}
+
 			ctx.table.AddColumn(col)
 			for indexName, indexType := range col.Indexes {
 				addIndex(indexName, ctx.table, col, indexType)


### PR DESCRIPTION
Added new syntax like `extends('Prefix')` to enable matching all
extended fields as `PrefixFieldName`.

Close go-xorm/xorm#1270