### PR TITLE
Fix spelling inconsistency and typos

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1354,31 +1354,31 @@ func (engine *Engine) DropIndexes(bean interface{}) error {
 }
 
 // Exec raw sql
-func (engine *Engine) Exec(sqlorArgs ...interface{}) (sql.Result, error) {
+func (engine *Engine) Exec(sqlOrArgs ...interface{}) (sql.Result, error) {
 	session := engine.NewSession()
 	defer session.Close()
-	return session.Exec(sqlorArgs...)
+	return session.Exec(sqlOrArgs...)
 }
 
 // Query a raw sql and return records as []map[string][]byte
-func (engine *Engine) Query(sqlorArgs ...interface{}) (resultsSlice []map[string][]byte, err error) {
+func (engine *Engine) Query(sqlOrArgs ...interface{}) (resultsSlice []map[string][]byte, err error) {
 	session := engine.NewSession()
 	defer session.Close()
-	return session.Query(sqlorArgs...)
+	return session.Query(sqlOrArgs...)
 }
 
 // QueryString runs a raw sql and return records as []map[string]string
-func (engine *Engine) QueryString(sqlorArgs ...interface{}) ([]map[string]string, error) {
+func (engine *Engine) QueryString(sqlOrArgs ...interface{}) ([]map[string]string, error) {
 	session := engine.NewSession()
 	defer session.Close()
-	return session.QueryString(sqlorArgs...)
+	return session.QueryString(sqlOrArgs...)
 }
 
 // QueryInterface runs a raw sql and return records as []map[string]interface{}
-func (engine *Engine) QueryInterface(sqlorArgs ...interface{}) ([]map[string]interface{}, error) {
+func (engine *Engine) QueryInterface(sqlOrArgs ...interface{}) ([]map[string]interface{}, error) {
 	session := engine.NewSession()
 	defer session.Close()
-	return session.QueryInterface(sqlorArgs...)
+	return session.QueryInterface(sqlOrArgs...)
 }
 
 // Insert one or more records

--- a/interface.go
+++ b/interface.go
@@ -28,7 +28,7 @@ type Interface interface {
 	Delete(interface{}) (int64, error)
 	Distinct(columns ...string) *Session
 	DropIndexes(bean interface{}) error
-	Exec(sqlOrAgrs ...interface{}) (sql.Result, error)
+	Exec(sqlOrArgs ...interface{}) (sql.Result, error)
 	Exist(bean ...interface{}) (bool, error)
 	Find(interface{}, ...interface{}) error
 	FindAndCount(interface{}, ...interface{}) (int64, error)
@@ -50,9 +50,9 @@ type Interface interface {
 	Omit(columns ...string) *Session
 	OrderBy(order string) *Session
 	Ping() error
-	Query(sqlOrAgrs ...interface{}) (resultsSlice []map[string][]byte, err error)
-	QueryInterface(sqlorArgs ...interface{}) ([]map[string]interface{}, error)
-	QueryString(sqlorArgs ...interface{}) ([]map[string]string, error)
+	Query(sqlOrArgs ...interface{}) (resultsSlice []map[string][]byte, err error)
+	QueryInterface(sqlOrArgs ...interface{}) ([]map[string]interface{}, error)
+	QueryString(sqlOrArgs ...interface{}) ([]map[string]string, error)
 	Rows(bean interface{}) (*Rows, error)
 	SetExpr(string, string) *Session
 	SQL(interface{}, ...interface{}) *Session

--- a/session_query.go
+++ b/session_query.go
@@ -15,9 +15,9 @@ import (
 	"github.com/go-xorm/core"
 )
 
-func (session *Session) genQuerySQL(sqlorArgs ...interface{}) (string, []interface{}, error) {
-	if len(sqlorArgs) > 0 {
-		return convertSQLOrArgs(sqlorArgs...)
+func (session *Session) genQuerySQL(sqlOrArgs ...interface{}) (string, []interface{}, error) {
+	if len(sqlOrArgs) > 0 {
+		return convertSQLOrArgs(sqlOrArgs...)
 	}
 
 	if session.statement.RawSQL != "" {
@@ -78,12 +78,12 @@ func (session *Session) genQuerySQL(sqlorArgs ...interface{}) (string, []interfa
 }
 
 // Query runs a raw sql and return records as []map[string][]byte
-func (session *Session) Query(sqlorArgs ...interface{}) ([]map[string][]byte, error) {
+func (session *Session) Query(sqlOrArgs ...interface{}) ([]map[string][]byte, error) {
 	if session.isAutoClose {
 		defer session.Close()
 	}
 
-	sqlStr, args, err := session.genQuerySQL(sqlorArgs...)
+	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -227,12 +227,12 @@ func rows2SliceString(rows *core.Rows) (resultsSlice [][]string, err error) {
 }
 
 // QueryString runs a raw sql and return records as []map[string]string
-func (session *Session) QueryString(sqlorArgs ...interface{}) ([]map[string]string, error) {
+func (session *Session) QueryString(sqlOrArgs ...interface{}) ([]map[string]string, error) {
 	if session.isAutoClose {
 		defer session.Close()
 	}
 
-	sqlStr, args, err := session.genQuerySQL(sqlorArgs...)
+	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -247,12 +247,12 @@ func (session *Session) QueryString(sqlorArgs ...interface{}) ([]map[string]stri
 }
 
 // QuerySliceString runs a raw sql and return records as [][]string
-func (session *Session) QuerySliceString(sqlorArgs ...interface{}) ([][]string, error) {
+func (session *Session) QuerySliceString(sqlOrArgs ...interface{}) ([][]string, error) {
 	if session.isAutoClose {
 		defer session.Close()
 	}
 
-	sqlStr, args, err := session.genQuerySQL(sqlorArgs...)
+	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -300,12 +300,12 @@ func rows2Interfaces(rows *core.Rows) (resultsSlice []map[string]interface{}, er
 }
 
 // QueryInterface runs a raw sql and return records as []map[string]interface{}
-func (session *Session) QueryInterface(sqlorArgs ...interface{}) ([]map[string]interface{}, error) {
+func (session *Session) QueryInterface(sqlOrArgs ...interface{}) ([]map[string]interface{}, error) {
 	if session.isAutoClose {
 		defer session.Close()
 	}
 
-	sqlStr, args, err := session.genQuerySQL(sqlorArgs...)
+	sqlStr, args, err := session.genQuerySQL(sqlOrArgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/session_raw.go
+++ b/session_raw.go
@@ -194,14 +194,14 @@ func (session *Session) exec(sqlStr string, args ...interface{}) (sql.Result, er
 	return session.DB().ExecContext(session.ctx, sqlStr, args...)
 }
 
-func convertSQLOrArgs(sqlorArgs ...interface{}) (string, []interface{}, error) {
-	switch sqlorArgs[0].(type) {
+func convertSQLOrArgs(sqlOrArgs ...interface{}) (string, []interface{}, error) {
+	switch sqlOrArgs[0].(type) {
 	case string:
-		return sqlorArgs[0].(string), sqlorArgs[1:], nil
+		return sqlOrArgs[0].(string), sqlOrArgs[1:], nil
 	case *builder.Builder:
-		return sqlorArgs[0].(*builder.Builder).ToSQL()
+		return sqlOrArgs[0].(*builder.Builder).ToSQL()
 	case builder.Builder:
-		bd := sqlorArgs[0].(builder.Builder)
+		bd := sqlOrArgs[0].(builder.Builder)
 		return bd.ToSQL()
 	}
 
@@ -209,16 +209,16 @@ func convertSQLOrArgs(sqlorArgs ...interface{}) (string, []interface{}, error) {
 }
 
 // Exec raw sql
-func (session *Session) Exec(sqlorArgs ...interface{}) (sql.Result, error) {
+func (session *Session) Exec(sqlOrArgs ...interface{}) (sql.Result, error) {
 	if session.isAutoClose {
 		defer session.Close()
 	}
 
-	if len(sqlorArgs) == 0 {
+	if len(sqlOrArgs) == 0 {
 		return nil, ErrUnSupportedType
 	}
 
-	sqlStr, args, err := convertSQLOrArgs(sqlorArgs...)
+	sqlStr, args, err := convertSQLOrArgs(sqlOrArgs...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix spelling inconsistency :
`sqlorArgs` => `sqlOrArgs`

Fix typo :
`sqlOrAgrs` => `sqlOrArgs`