### PR TITLE
To support sql comment.

### DIFF
--- a/session.go
+++ b/session.go
@@ -57,6 +57,7 @@ type Session struct {
 	//beforeSQLExec func(string, ...interface{})
 	lastSQL     string
 	lastSQLArgs []interface{}
+	comment     string
 
 	ctx         context.Context
 	sessionType sessionType
@@ -154,6 +155,12 @@ func (session *Session) After(closures func(interface{})) *Session {
 // Table can input a string or pointer to struct for special a table to operate.
 func (session *Session) Table(tableNameOrBean interface{}) *Session {
 	session.statement.Table(tableNameOrBean)
+	return session
+}
+
+// Set comment for select statement
+func (session *Session) Comment(comment string) *Session {
+	session.comment = comment
 	return session
 }
 

--- a/session_query.go
+++ b/session_query.go
@@ -20,6 +20,7 @@ func (session *Session) genQuerySQL(sqlOrArgs ...interface{}) (string, []interfa
 		return convertSQLOrArgs(sqlOrArgs...)
 	}
 
+	sqlStr = session.comment + sqlStr
 	if session.statement.RawSQL != "" {
 		return session.statement.RawSQL, session.statement.RawParams, nil
 	}


### PR DESCRIPTION
Some dbproxy middleware use sql comment to make make a query on master node.
Example:

db.Table("test").Comment("/*m:master*/").Get( ptrObj )

The sql builder will output:
/*m:master*/SELECT * from test ....;