### PR TITLE
reflect.Value.Bytes() should only be called when reflect.Value.Kind()…

### DIFF
--- a/session_convert.go
+++ b/session_convert.go
@@ -640,7 +640,7 @@ func (session *Session) value2Interface(col *core.Column, fieldValue reflect.Val
 		} else if col.SQLType.IsBlob() {
 			var bytes []byte
 			var err error
-			if (k == reflect.Array || k == reflect.Slice) &&
+			if (k == reflect.Slice) &&
 				(fieldValue.Type().Elem().Kind() == reflect.Uint8) {
 				bytes = fieldValue.Bytes()
 			} else {


### PR DESCRIPTION
Fix for issue [#1345](https://github.com/go-xorm/xorm/issues/1345).

I noticed that in value2Interface function in session_convert.go, we are using reflect.Value.Bytes() function when the fieldType is reflect.Array OR reflect.Slice. However, go's reflect.Value.Bytes() only works when the value is of type reflect.Slice, and panics otherwise.

I would propose that change the if condition from:
```
if (k == reflect.Array || k == reflect.Slice) && (...) {
    // logic
}
```
to
```
if (k == reflect.Slice) && (...) {
    // logic
}
```
This PR fixes this.