### PR TITLE
fix issue #448

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -1157,8 +1157,12 @@ func (statement *Statement) genSelectSQL(columnStr, condSQL string, needLimit, n
 			if statement.Start != 0 || statement.LimitN != 0 {
 				oldString := buf.String()
 				buf.Reset()
+				rawColStr := columnStr
+				if rawColStr == "*" {
+					rawColStr = "at.*"
+				}
 				fmt.Fprintf(&buf, "SELECT %v FROM (SELECT %v,ROWNUM RN FROM (%v) at WHERE ROWNUM <= %d) aat WHERE RN > %d",
-					columnStr, columnStr, oldString, statement.Start+statement.LimitN, statement.Start)
+					columnStr, rawColStr, oldString, statement.Start+statement.LimitN, statement.Start)
 			}
 		}
 	}


### PR DESCRIPTION
In xorm implementation, the statement can't know the struct joined in, so use '\*' instead of the columns from target struct. But '*' can't be use in a subquery here (https://github.com/go-xorm/xorm/blob/v0.7.4/statement.go#L1160). Check the `columnStr` before use it .