### PR TITLE
fix bug in mysql: default value CURRENT_TIMESTAMP #1391

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -411,7 +411,11 @@ func (db *mysql) GetColumns(tableName string) ([]string, map[string]*core.Column
 			col.IsAutoIncrement = true
 		}
 
-		if col.SQLType.IsText() || col.SQLType.IsTime() {
+		if col.SQLType.IsTime() && col.Default == "CURRENT_TIMESTAMP" {
+			if strings.Contains(extra, "CURRENT_TIMESTAMP") {
+				col.Default = "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+			}
+		} else if col.SQLType.IsText() || col.SQLType.IsTime() {
 			if col.Default != "" {
 				col.Default = "'" + col.Default + "'"
 			} else {

--- a/engine.go
+++ b/engine.go
@@ -1526,7 +1526,7 @@ func (engine *Engine) Import(r io.Reader) ([]sql.Result, error) {
 		if atEOF && len(data) == 0 {
 			return 0, nil, nil
 		}
-		if i := bytes.IndexByte(data, ';'); i >= 0 {
+		if i := bytes.Index(data, []byte(";\n")); i >= 0 {
 			return i + 1, data[0:i], nil
 		}
 		// If we're at EOF, we have a final, non-terminated line. Return it.


### PR DESCRIPTION
fix mysql  table structure default value 'CURRENT_TIMESTAMP' and 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP' will lead to dump sql fail #1391 