### PR TITLE
fix bug for mis-converting uint64 value to an int64 one

### DIFF
--- a/engine_cond.go
+++ b/engine_cond.go
@@ -127,8 +127,7 @@ func (engine *Engine) buildConds(table *core.Table, bean interface{},
 			if !requiredField && fieldValue.Uint() == 0 {
 				continue
 			}
-			t := int64(fieldValue.Uint())
-			val = reflect.ValueOf(&t).Interface()
+			val = fieldValue.Interface()
 		case reflect.Struct:
 			if fieldType.ConvertibleTo(core.TimeType) {
 				t := fieldValue.Convert(core.TimeType).Interface().(time.Time)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-xorm/xorm
+module github.com/rosbit/xorm
 
 go 1.11
 

--- a/session_convert.go
+++ b/session_convert.go
@@ -664,7 +664,7 @@ func (session *Session) value2Interface(col *core.Column, fieldValue reflect.Val
 		}
 		return nil, ErrUnSupportedType
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
-		return int64(fieldValue.Uint()), nil
+		return fieldValue.Uint(), nil
 	default:
 		return fieldValue.Interface(), nil
 	}

--- a/statement.go
+++ b/statement.go
@@ -385,8 +385,7 @@ func (statement *Statement) buildUpdates(bean interface{},
 			if !requiredField && fieldValue.Uint() == 0 {
 				continue
 			}
-			t := int64(fieldValue.Uint())
-			val = reflect.ValueOf(&t).Interface()
+			val = fieldValue.Interface()
 		case reflect.Struct:
 			if fieldType.ConvertibleTo(core.TimeType) {
 				t := fieldValue.Convert(core.TimeType).Interface().(time.Time)


### PR DESCRIPTION
 - If an uint64 value is greater than 0x7FFFFFFFFFFFFFFF(the max value of int64),  the behavior is strange, sometimes a negative value will stored in db, or an error of "value out of range" occurs.
 - In source files statement.go, session_convert.go, engine_cond.go, I found there're strange convertion like this:
   ```
   if !requiredField && fieldValue.Uint() == 0 {
	 continue
   }
   t := int64(fieldValue.Uint())
   val = reflect.ValueOf(&t).Interface()
   ```
 - I modify them, it works now.
   ```
   val = fieldValue.Interface()
   ```